### PR TITLE
Added setting to render soft line breaks as line breaks

### DIFF
--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="ListTests.cs" />
     <Compile Include="HtmlTests.cs" />
+    <Compile Include="SettingsTests.cs" />
     <Compile Include="UrlTests.cs" />
     <Compile Include="EmphasisTests.cs" />
     <Compile Include="Helpers.cs" />

--- a/CommonMark.Tests/SettingsTests.cs
+++ b/CommonMark.Tests/SettingsTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class SettingsTests
+    {
+        [TestMethod]
+        [TestCategory("Inlines - Soft line break")]
+        public void RenderSoftLineBreakAsLineBreak()
+        {
+            // Arrange
+            var commonMark = Helpers.Normalize("A\nB\nC");
+            var expected = Helpers.Normalize("<p>A<br />\nB<br />\nC</p>");
+            var settings = CommonMarkSettings.Default.Clone();
+            settings.RenderSoftLineBreaksAsLineBreaks = true;
+
+            Helpers.LogValue("CommonMark", commonMark);
+            Helpers.LogValue("Expected", expected);
+
+            // Act
+            var actual = CommonMarkConverter.Convert(commonMark, settings);
+
+            // Assert
+            Helpers.LogValue("Actual", actual);
+            Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
+        }
+    }
+}

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -14,6 +14,11 @@ namespace CommonMark
         /// </summary>
         public OutputFormat OutputFormat { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether soft line breaks should be rendered as hard line breaks.
+        /// </summary>
+        public bool RenderSoftLineBreaksAsLineBreaks { get; set; }
+
         private Func<string, string> _uriResolver;
         /// <summary>
         /// Gets or sets the delegate that is used to resolve addresses during rendering process. Can be used to process application relative URLs (<c>~/foo/bar</c>).

--- a/CommonMark/Formatter/HtmlPrinter.cs
+++ b/CommonMark/Formatter/HtmlPrinter.cs
@@ -433,7 +433,10 @@ namespace CommonMark.Formatter
                         break;
 
                     case InlineTag.SoftBreak:
-                        writer.WriteLine();
+                        if (settings.RenderSoftLineBreaksAsLineBreaks)
+                            writer.WriteLine("<br />");
+                        else
+                            writer.WriteLine();
                         break;
 
                     case InlineTag.Code:


### PR DESCRIPTION
Based on issue https://github.com/Knagis/CommonMark.NET/issues/11

Allows you to set a setting to render soft line breaks as hard line breaks.
