### PR TITLE
Image src attributes are getting encoded which messes up query parameters

### DIFF
--- a/CommonMark.Tests/UrlTests.cs
+++ b/CommonMark.Tests/UrlTests.cs
@@ -53,14 +53,22 @@ namespace CommonMark.Tests
             Assert.IsTrue(gotException, "A required exception was not thrown.");
         }
 
-		[TestMethod]
-		[TestCategory("Inlines - Image")]
-		public void Image()
-		{
-			var settings = CommonMarkSettings.Default.Clone();
+        [TestMethod]
+        [TestCategory("Inlines - Image")]
+        public void Images_should_not_have_URL_query_string_separators_escaped()
+        {
+            var settings = CommonMarkSettings.Default.Clone();
 
-			Helpers.ExecuteTest(@"![image](http://localhost/image.jpg?id=foo&file=bar)", "<p><img src=\"http://localhost/image.jpg?id=foo&file=bar\" alt=\"image\" /></p>", settings);
-		}
-
-	}
+            Helpers.ExecuteTest(@"![image](http://localhost/image.jpg?id=foo&file=bar)", "<p><img src=\"http://localhost/image.jpg?id=foo&file=bar\" alt=\"image\" /></p>", settings);
+        }
+        
+        [TestMethod]
+        [TestCategory("Inlines - Links")]
+        public void Links_should_not_have_URL_query_string_separators_escaped()
+        {
+            var settings = CommonMarkSettings.Default.Clone();
+        
+            Helpers.ExecuteTest(@"[link](http://localhost/route?id=foo&file=bar)", "<p><a href=\"http://localhost/route?id=foo&file=bar\">link</a></p>", settings);
+         }
+    }
 }

--- a/CommonMark.Tests/UrlTests.cs
+++ b/CommonMark.Tests/UrlTests.cs
@@ -52,5 +52,15 @@ namespace CommonMark.Tests
 
             Assert.IsTrue(gotException, "A required exception was not thrown.");
         }
-    }
+
+		[TestMethod]
+		[TestCategory("Inlines - Image")]
+		public void Image()
+		{
+			var settings = CommonMarkSettings.Default.Clone();
+
+			Helpers.ExecuteTest(@"![image](http://localhost/image.jpg?id=foo&file=bar)", "<p><img src=\"http://localhost/image.jpg?id=foo&file=bar\" alt=\"image\" /></p>", settings);
+		}
+
+	}
 }

--- a/CommonMark/Formatter/HtmlPrinter.cs
+++ b/CommonMark/Formatter/HtmlPrinter.cs
@@ -21,7 +21,7 @@ namespace CommonMark.Formatter
         private static readonly bool[] UrlSafeCharacters = new[] {
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-            false, true,  false, true,  true,  true,  false, false, true,  true,  true,  true,  true,  true,  true,  true, 
+            false, true,  false, true,  true,  true,  true, false, true,  true,  true,  true,  true,  true,  true,  true, 
             true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, true,  false, true, 
             true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true, 
             true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, false, false, false, true, 
@@ -57,13 +57,7 @@ namespace CommonMark.Formatter
             {
                 c = buffer[pos];
 
-                if (c == '&')
-                {
-                    target.WriteConstant(buffer, lastPos, pos - lastPos);
-                    lastPos = pos + 1;
-                    target.WriteConstant(EscapeHtmlAmpersand);
-                }
-                else if (c < 128 && !UrlSafeCharacters[c])
+                if (c < 128 && !UrlSafeCharacters[c])
                 {
                     target.WriteConstant(buffer, lastPos, pos - lastPos);
                     lastPos = pos + 1;


### PR DESCRIPTION
This PR includes a failing test where an image URL is getting encoded. This messes up query string parameters. Which in our case is preventing downloads from S3 which have a required payload in the query string.

I am willing to help correct this but I am not yet familiar with the how this codebase. Any pointers about where to start are appreciated.