### PR TITLE
Open header tag are not closed when tracking position.

### DIFF
--- a/CommonMark/Formatter/HtmlPrinter.cs
+++ b/CommonMark/Formatter/HtmlPrinter.cs
@@ -301,6 +301,7 @@ namespace CommonMark.Formatter
                         {
                             writer.WriteConstant("<h" + x.ToString(CultureInfo.InvariantCulture));
                             PrintPosition(writer, block);
+                            writer.Write('>');
                             InlinesToHtml(writer, block.InlineContent, settings, inlineStack);
                             writer.WriteLineConstant(x > 0 && x < 7 ? HeaderCloserTags[x - 1] : "</h" + x.ToString(CultureInfo.InvariantCulture) + ">");
                         }


### PR DESCRIPTION
Before editing:

    <h1 data-sourcepos="0-36"<span data-sourcepos="0-16">...

After editing:

    <h1 data-sourcepos="0-36"><span data-sourcepos="0-16">...