### PR TITLE
Added Visitor for HtmlPrinter (IHtmlPrinterVisitor and tests)

### DIFF
--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -50,6 +50,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="HtmlPrinterVisitorTests.cs" />
     <Compile Include="ListTests.cs" />
     <Compile Include="HtmlTests.cs" />
     <Compile Include="SettingsTests.cs" />

--- a/CommonMark.Tests/HtmlPrinterVisitorTests.cs
+++ b/CommonMark.Tests/HtmlPrinterVisitorTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommonMark.Formatter;
+using CommonMark.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+	[TestClass]
+	public class HtmlPrinterVisitorTests
+	{
+		[TestCleanup]
+		public void TestCleanup()
+		{
+			CommonMarkSettings.Default.HtmlPrinterVisitor = null; // for the other tests.
+		}
+
+		[TestMethod]
+		[TestCategory("Inlines - visitor")]
+		public void ShouldCallOnEnter()
+		{
+			// Arrange
+			string markdown = "[![moon](moon.jpg)](/uri)";
+			string expected = "<p>Enter text<a href=\"link-onenter-url\">Enter text<img src=\"image-onenter-url\" alt=\"moon\" /></a></p>";
+
+			var htmlPrinterVisitorMock = new HtmlPrinterVisitorMock();
+			htmlPrinterVisitorMock.EnterText = "Enter text";
+			var settings = new CommonMarkSettings() { HtmlPrinterVisitor = htmlPrinterVisitorMock };
+
+			// Act
+			string actual = CommonMarkConverter.Convert(markdown, settings);
+
+			// Assert
+			Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
+		}
+
+		[TestMethod]
+		[TestCategory("Inlines - visitor")]
+		public void ShouldCallOnExit()
+		{
+			// Arrange
+			string markdown = "[![moon](moon.jpg)](/uri)";
+			string expected = "<p><a href=\"/uri\">Exit text<img src=\"moon.jpg\" alt=\"moon\" />Exit text</a></p>";
+
+			var htmlPrinterVisitorMock = new HtmlPrinterVisitorMock();
+			htmlPrinterVisitorMock.ExitText = "Exit text";
+			var settings = new CommonMarkSettings() { HtmlPrinterVisitor = htmlPrinterVisitorMock };
+
+			// Act
+			string actual = CommonMarkConverter.Convert(markdown, settings);
+
+			// Assert
+			Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
+		}
+	}
+
+	public class HtmlPrinterVisitorMock : IHtmlPrinterVisitor
+	{
+		// The text before every tag
+		public string EnterText { get; set; }
+
+		// The text after every tag
+		public string ExitText { get; set; }
+
+		public string OnEnter(Inline inline)
+		{
+			if (!string.IsNullOrEmpty(EnterText))
+			{
+				switch (inline.Tag)
+				{
+					case InlineTag.Image:
+						inline.Linkable.Url = "image-onenter-url";
+						break;
+
+					case InlineTag.Link:
+						inline.Linkable.Url = "link-onenter-url";
+						break;
+				}
+			}
+
+			return EnterText;
+		}
+
+		public string OnExit(Inline inline)
+		{
+			return ExitText;
+		}
+	}
+}

--- a/CommonMark/CommonMark.Base.csproj
+++ b/CommonMark/CommonMark.Base.csproj
@@ -47,6 +47,7 @@
     <Compile Include="CommonMarkConverter.cs" />
     <Compile Include="CommonMarkException.cs" />
     <Compile Include="CommonMarkSettings.cs" />
+    <Compile Include="Formatter\IHtmlPrinterVisitor.cs" />
     <Compile Include="Func.cs" />
     <Compile Include="OutputFormat.cs" />
     <Compile Include="Parser\EntityDecoder.cs" />

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using CommonMark.Formatter;
 
 namespace CommonMark
 {
@@ -56,6 +57,11 @@ namespace CommonMark
         /// future conversions that do not specify their own settings.
         /// </summary>
         public static CommonMarkSettings Default { get { return _default; } }
+
+		/// <summary>
+		/// A <see cref="IHtmlPrinterVisitor"/> called during HTML conversion.
+		/// </summary>
+		public IHtmlPrinterVisitor HtmlPrinterVisitor { get; set; }
 
         /// <summary>
         /// Creates a copy of this configuration object.

--- a/CommonMark/Formatter/HtmlPrinter.cs
+++ b/CommonMark/Formatter/HtmlPrinter.cs
@@ -422,6 +422,12 @@ namespace CommonMark.Formatter
             {
                 visitChildren = false;
 
+				if (settings != null && settings.HtmlPrinterVisitor != null)
+				{
+					string enterText = settings.HtmlPrinterVisitor.OnEnter(inline);
+					writer.Write(enterText);
+				}
+
                 switch (inline.Tag)
                 {
                     case InlineTag.String:
@@ -517,6 +523,12 @@ namespace CommonMark.Formatter
                     default:
                         throw new CommonMarkException("Inline type " + inline.Tag + " is not supported.", inline);
                 }
+
+				if (settings != null && settings.HtmlPrinterVisitor != null)
+				{
+					string exitText = settings.HtmlPrinterVisitor.OnExit(inline);
+					writer.Write(exitText);
+				}
 
                 if (visitChildren)
                 {

--- a/CommonMark/Formatter/IHtmlPrinterVisitor.cs
+++ b/CommonMark/Formatter/IHtmlPrinterVisitor.cs
@@ -1,0 +1,11 @@
+using System.IO;
+using CommonMark.Syntax;
+
+namespace CommonMark.Formatter
+{
+	public interface IHtmlPrinterVisitor
+	{
+		string OnEnter(Inline inline);
+		string OnExit(Inline inline);
+	}
+}


### PR DESCRIPTION
I need to change the base url of all images and also for links, but individually (so I can't use the UrlResolver). This patch adds a visitor (`IHtmlPrinterVisitor`) to the `HtmlPrinter` class, and is configurable via the `CommonMarkdownSettings`. There's a few tests to illustrate how it works - you might need to change from tabs to spaces in the patch.

I'm not sure of the usefulness of OnExit in the interface, I've left it in but it's probably not much value.