### PR TITLE
Subscript, superscript and case-sensitive reference labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,3 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
-packages/

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+packages/

--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SettingsTests.cs" />
     <Compile Include="GeneralTests.cs" />
     <Compile Include="SubscriptTests.cs" />
+    <Compile Include="SuperscriptTests.cs" />
     <Compile Include="UrlTests.cs" />
     <Compile Include="EmphasisTests.cs" />
     <Compile Include="Helpers.cs" />

--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="HtmlTests.cs" />
     <Compile Include="SettingsTests.cs" />
     <Compile Include="GeneralTests.cs" />
+    <Compile Include="SubscriptTests.cs" />
     <Compile Include="UrlTests.cs" />
     <Compile Include="EmphasisTests.cs" />
     <Compile Include="Helpers.cs" />

--- a/CommonMark.Tests/SubscriptTests.cs
+++ b/CommonMark.Tests/SubscriptTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class SubscriptTests
+    {
+        private static CommonMarkSettings _settings;
+        private static CommonMarkSettings Settings
+        {
+            get
+            {
+                var s = _settings;
+                if (s == null)
+                {
+                    s = CommonMarkSettings.Default.Clone();
+                    s.AdditionalFeatures |= CommonMarkAdditionalFeatures.SubscriptTilde;
+                    _settings = s;
+                }
+                return s;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptDisabledByDefault()
+        {
+            Helpers.ExecuteTest("foo ~bar~", "<p>foo ~bar~</p>");
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample0()
+        {
+            Helpers.ExecuteTest("foo ~bar~", "<p>foo <sub>bar</sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample1()
+        {
+            Helpers.ExecuteTest("foo ~~bar~", "<p>foo ~<sub>bar</sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample2()
+        {
+            Helpers.ExecuteTest("foo ~~bar~", "<p>foo ~<sub>bar</sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample3()
+        {
+            Helpers.ExecuteTest("foo ~~bar~ asd~", "<p>foo <sub><sub>bar</sub> asd</sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample4()
+        {
+            Helpers.ExecuteTest("foo ~*bar~*", "<p>foo <sub>*bar</sub>*</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample5()
+        {
+            Helpers.ExecuteTest("foo *~bar~*", "<p>foo <em><sub>bar</sub></em></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample6()
+        {
+            Helpers.ExecuteTest("foo **~bar**~", "<p>foo <strong>~bar</strong>~</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample7()
+        {
+            Helpers.ExecuteTest("~bar~~", "<p><sub>bar</sub>~</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample8()
+        {
+            // make sure that the fenced code blocks are not broken because of this feature
+            Helpers.ExecuteTest("~~~foo\n~", "<pre><code class=\"language-foo\">~\n</code></pre>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample9()
+        {
+            Helpers.ExecuteTest("foo ~~bar~~", "<p>foo <sub><sub>bar</sub></sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample10()
+        {
+            // '[' char in the middle will delay the ~~ match to the post-process phase.
+            Helpers.ExecuteTest("foo ~~ba[r~~", "<p>foo <sub><sub>ba[r</sub></sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample10a()
+        {
+            // '[' char in the middle will delay the ~~ match to the post-process phase.
+            Helpers.ExecuteTest("foo ~~ba[r~", "<p>foo ~<sub>ba[r</sub></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample10b()
+        {
+            // '[' char in the middle will delay the ~~ match to the post-process phase.
+            Helpers.ExecuteTest("foo ~ba[r~~", "<p>foo <sub>ba[r</sub>~</p>", Settings);
+        }
+
+        //No 10c for subscript
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample10d()
+        {
+            // '[' char in the middle will delay the ~~ match to the post-process phase.
+            Helpers.ExecuteTest("~~[foo~ bar", "<p>~<sub>[foo</sub> bar</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample101()
+        {
+            Helpers.ExecuteTest("foo ~ bar~", "<p>foo ~ bar~</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample102()
+        {
+            Helpers.ExecuteTest("foo ~bar ~", "<p>foo ~bar ~</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Subscript")]
+        public void SubscriptExample103()
+        {
+            Helpers.ExecuteTest("foo ~ bar ~", "<p>foo ~ bar ~</p>", Settings);
+        }
+    }
+}

--- a/CommonMark.Tests/SuperscriptTests.cs
+++ b/CommonMark.Tests/SuperscriptTests.cs
@@ -94,7 +94,7 @@ namespace CommonMark.Tests
         public void SuperscriptExample8()
         {
             // make sure that the fenced code blocks are not broken because of this feature
-            Helpers.ExecuteTest("^^^foo\n^", "<pre><code class=\"language-foo\">^\n</code></pre>", Settings);
+            Helpers.ExecuteTest("~~~foo\n^", "<pre><code class=\"language-foo\">^\n</code></pre>", Settings);
         }
 
         [TestMethod]

--- a/CommonMark.Tests/SuperscriptTests.cs
+++ b/CommonMark.Tests/SuperscriptTests.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class SuperscriptTests
+    {
+        private static CommonMarkSettings _settings;
+        private static CommonMarkSettings Settings
+        {
+            get
+            {
+                var s = _settings;
+                if (s == null)
+                {
+                    s = CommonMarkSettings.Default.Clone();
+                    s.AdditionalFeatures |= CommonMarkAdditionalFeatures.SuperscriptCaret;
+                    _settings = s;
+                }
+                return s;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptDisabledByDefault()
+        {
+            Helpers.ExecuteTest("foo ^bar^", "<p>foo ^bar^</p>");
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample0()
+        {
+            Helpers.ExecuteTest("foo ^bar^", "<p>foo <sup>bar</sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample1()
+        {
+            Helpers.ExecuteTest("foo ^^bar^", "<p>foo ^<sup>bar</sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample2()
+        {
+            Helpers.ExecuteTest("foo ^^bar^", "<p>foo ^<sup>bar</sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample3()
+        {
+            Helpers.ExecuteTest("foo ^^bar^ asd^", "<p>foo <sup><sup>bar</sup> asd</sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample4()
+        {
+            Helpers.ExecuteTest("foo ^*bar^*", "<p>foo <sup>*bar</sup>*</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample5()
+        {
+            Helpers.ExecuteTest("foo *^bar^*", "<p>foo <em><sup>bar</sup></em></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample6()
+        {
+            Helpers.ExecuteTest("foo **^bar**^", "<p>foo <strong>^bar</strong>^</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample7()
+        {
+            Helpers.ExecuteTest("^bar^^", "<p><sup>bar</sup>^</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample8()
+        {
+            // make sure that the fenced code blocks are not broken because of this feature
+            Helpers.ExecuteTest("^^^foo\n^", "<pre><code class=\"language-foo\">^\n</code></pre>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample9()
+        {
+            Helpers.ExecuteTest("foo ^^bar^^", "<p>foo <sup><sup>bar</sup></sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample10()
+        {
+            // '[' char in the middle will delay the ^^ match to the post-process phase.
+            Helpers.ExecuteTest("foo ^^ba[r^^", "<p>foo <sup><sup>ba[r</sup></sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample10a()
+        {
+            // '[' char in the middle will delay the ^^ match to the post-process phase.
+            Helpers.ExecuteTest("foo ^^ba[r^", "<p>foo ^<sup>ba[r</sup></p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample10b()
+        {
+            // '[' char in the middle will delay the ^^ match to the post-process phase.
+            Helpers.ExecuteTest("foo ^ba[r^^", "<p>foo <sup>ba[r</sup>^</p>", Settings);
+        }
+
+        //No 10c for superscript
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample10d()
+        {
+            // '[' char in the middle will delay the ^^ match to the post-process phase.
+            Helpers.ExecuteTest("^^[foo^ bar", "<p>^<sup>[foo</sup> bar</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample101()
+        {
+            Helpers.ExecuteTest("foo ^ bar^", "<p>foo ^ bar^</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample102()
+        {
+            Helpers.ExecuteTest("foo ^bar ^", "<p>foo ^bar ^</p>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Inlines - Superscript")]
+        public void SuperscriptExample103()
+        {
+            Helpers.ExecuteTest("foo ^ bar ^", "<p>foo ^ bar ^</p>", Settings);
+        }
+    }
+}

--- a/CommonMark/CommonMark.Base.csproj
+++ b/CommonMark/CommonMark.Base.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <BuildMode Condition=" '$(BuildMode)' == '' ">portable</BuildMode>
@@ -15,6 +16,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <NuGetPackageImportStamp>2d99cddc</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -88,7 +90,14 @@
     <EmbeddedResource Include="..\CommonMark.NET.nuspec">
       <Link>Properties\CommonMark.NET.nuspec</Link>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\public.snk" />
   </ItemGroup>
   <Import Project="CommonMark.Targets.csproj" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
 </Project>

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -26,11 +26,6 @@ namespace CommonMark
         SubscriptTilde = 2,
 
         /// <summary>
-        /// The parser will recognize both <see cref="StrikethroughTilde"/> and <see cref="SubscriptTilde"/>.
-        /// </summary>
-        Tilde = 3,
-
-        /// <summary>
         /// The parser will recognize syntax <c>^foo^</c> that will be rendered as <c>&lt;sup&gt;foo&lt;/sup&gt;</c>.
         /// </summary>
         SuperscriptCaret = 4,

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -31,7 +31,7 @@ namespace CommonMark
         SuperscriptCaret = 4,
 
         /// <summary>
-        /// The parser will treat the case of reference labels with sensitivitiley.
+        /// The parser will treat reference labels as case sensitive.
         /// </summary>
         RespectReferenceCase = 0x100,
 

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,6 +21,11 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
+        /// The parser will treat the case of reference labels with sensitivitiley.
+        /// </summary>
+        RespectReferenceCase = 2,
+
+        /// <summary>
         /// All additional features are enabled.
         /// </summary>
         All = 0x7FFFFFFF

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,11 +21,6 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
-        /// The parser will treat the case of reference labels with sensitivitiley.
-        /// </summary>
-        RespectReferenceCase = 2,
-
-        /// <summary>
         /// All additional features are enabled.
         /// </summary>
         All = 0x7FFFFFFF

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,6 +21,21 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
+        /// The parser will recognize syntax <c>~foo~</c> that will be rendered as <c>&lt;sub&gt;foo&lt;/sub&gt;</c>.
+        /// </summary>
+        SubscriptTilde = 2,
+
+        /// <summary>
+        /// The parser will recognize syntax <c>^foo^</c> that will be rendered as <c>&lt;sup&gt;foo&lt;/sup&gt;</c>.
+        /// </summary>
+        SuperscriptCaret = 4,
+
+        /// <summary>
+        /// The parser will treat the case of reference labels with sensitivitiley.
+        /// </summary>
+        RespectReferenceCase = 0x100,
+
+        /// <summary>
         /// All additional features are enabled.
         /// </summary>
         All = 0x7FFFFFFF

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -26,6 +26,11 @@ namespace CommonMark
         SubscriptTilde = 2,
 
         /// <summary>
+        /// The parser will recognize both <see cref="StrikethroughTilde"/> and <see cref="SubscriptTilde"/>.
+        /// </summary>
+        Tilde = 3,
+
+        /// <summary>
         /// The parser will recognize syntax <c>^foo^</c> that will be rendered as <c>&lt;sup&gt;foo&lt;/sup&gt;</c>.
         /// </summary>
         SuperscriptCaret = 4,

--- a/CommonMark/CommonMarkConverter.cs
+++ b/CommonMark/CommonMarkConverter.cs
@@ -117,7 +117,7 @@ namespace CommonMark
                 reader.ReadLine(line);
                 while (line.Line != null)
                 {
-                    BlockMethods.IncorporateLine(line, ref cur);
+                    BlockMethods.IncorporateLine(line, ref cur, settings);
                     reader.ReadLine(line);
                 }
             }
@@ -138,7 +138,7 @@ namespace CommonMark
             {
                 do
                 {
-                    BlockMethods.Finalize(cur, line);
+                    BlockMethods.Finalize(cur, line, settings);
                     cur = cur.Parent;
                 } while (cur != null);
             }

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -120,12 +120,12 @@ namespace CommonMark
 
         #region [ Properties that cache structures used in the parsers ]
 
-        private Func<Parser.Subject, Syntax.Inline>[] _inlineParsers;
+        private Func<Parser.Subject, CommonMarkSettings, Syntax.Inline>[] _inlineParsers;
 
         /// <summary>
         /// Gets the delegates that parse inline elements according to these settings.
         /// </summary>
-        internal Func<Parser.Subject, Syntax.Inline>[] InlineParsers
+        internal Func<Parser.Subject, CommonMarkSettings, Syntax.Inline>[] InlineParsers
         {
             get
             {

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -495,6 +495,38 @@ namespace CommonMark.Formatters
                     }
                     break;
 
+                case InlineTag.Subscript:
+                    ignoreChildNodes = false;
+
+                    if (isOpening)
+                    {
+                        Write("<sub");
+                        if (Settings.TrackSourcePosition) WritePositionAttribute(inline);
+                        Write('>');
+                    }
+
+                    if (isClosing)
+                    {
+                        Write("</sub>");
+                    }
+                    break;
+
+                case InlineTag.Superscript:
+                    ignoreChildNodes = false;
+
+                    if (isOpening)
+                    {
+                        Write("<sup");
+                        if (Settings.TrackSourcePosition) WritePositionAttribute(inline);
+                        Write('>');
+                    }
+
+                    if (isClosing)
+                    {
+                        Write("</sup>");
+                    }
+                    break;
+
                 default:
                     throw new CommonMarkException("Inline type " + inline.Tag + " is not supported.", inline);
             }

--- a/CommonMark/Formatters/HtmlFormatterSlim.cs
+++ b/CommonMark/Formatters/HtmlFormatterSlim.cs
@@ -621,6 +621,24 @@ namespace CommonMark.Formatters
                         stackWithinLink = withinLink;
                         break;
 
+                    case InlineTag.Subscript:
+                        writer.WriteConstant("<sub");
+                        if (trackPositions) PrintPosition(writer, inline);
+                        writer.Write('>');
+                        stackLiteral = "</sub>";
+                        visitChildren = true;
+                        stackWithinLink = withinLink;
+                        break;
+
+                    case InlineTag.Superscript:
+                        writer.WriteConstant("<sup");
+                        if (trackPositions) PrintPosition(writer, inline);
+                        writer.Write('>');
+                        stackLiteral = "</sup>";
+                        visitChildren = true;
+                        stackWithinLink = withinLink;
+                        break;
+
                     default:
                         throw new CommonMarkException("Inline type " + inline.Tag + " is not supported.", inline);
                 }

--- a/CommonMark/Formatters/Printer.cs
+++ b/CommonMark/Formatters/Printer.cs
@@ -279,6 +279,16 @@ namespace CommonMark.Formatters
                         PrintPosition(trackPositions, writer, inline);
                         break;
 
+                    case InlineTag.Subscript:
+                        writer.Write("sub");
+                        PrintPosition(trackPositions, writer, inline);
+                        break;
+
+                    case InlineTag.Superscript:
+                        writer.Write("sup");
+                        PrintPosition(trackPositions, writer, inline);
+                        break;
+
                     default:
                         writer.Write("unknown: " + inline.Tag.ToString());
                         PrintPosition(trackPositions, writer, inline);

--- a/CommonMark/Func.cs
+++ b/CommonMark/Func.cs
@@ -5,6 +5,7 @@ namespace CommonMark
 #if v2_0
     /// <summary>An alternative to <c>System.Func</c> which is not present in .NET 2.0.</summary>
     public delegate TResult Func<in T, out TResult>(T arg);
+    public delegate TResult Func<in T1, in T2, out TResult>(T1 arg1, T2 arg2);
 
     /// <summary>An alternative to <c>System.Action</c> which is not present in .NET 2.0.</summary>
     public delegate void Action<in T1, in T2, in T3>(T1 arg1, T2 arg2, T3 arg3);

--- a/CommonMark/Func.cs
+++ b/CommonMark/Func.cs
@@ -5,6 +5,8 @@ namespace CommonMark
 #if v2_0
     /// <summary>An alternative to <c>System.Func</c> which is not present in .NET 2.0.</summary>
     public delegate TResult Func<in T, out TResult>(T arg);
+
+    /// <summary>An alternative to <c>System.Func</c> which is not present in .NET 2.0.</summary>
     public delegate TResult Func<in T1, in T2, out TResult>(T1 arg1, T2 arg2);
 
     /// <summary>An alternative to <c>System.Action</c> which is not present in .NET 2.0.</summary>

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -77,7 +77,7 @@ namespace CommonMark.Parser
         /// <summary>
         /// Break out of all containing lists
         /// </summary>
-        private static void BreakOutOfLists(ref Block blockRef, LineInfo line)
+        private static void BreakOutOfLists(ref Block blockRef, LineInfo line, CommonMarkSettings settings)
         {
             Block container = blockRef;
             Block b = container.Top;
@@ -90,16 +90,16 @@ namespace CommonMark.Parser
             {
                 while (container != null && container != b)
                 {
-                    Finalize(container, line);
+                    Finalize(container, line, settings);
                     container = container.Parent;
                 }
 
-                Finalize(b, line);
+                Finalize(b, line, settings);
                 blockRef = b.Parent;
             }
         }
 
-        public static void Finalize(Block b, LineInfo line)
+        public static void Finalize(Block b, LineInfo line, CommonMarkSettings settings)
         {
             // don't do anything if the block is already closed
             if (!b.IsOpen)
@@ -132,7 +132,7 @@ namespace CommonMark.Parser
                     var origPos = subj.Position;
                     while (subj.Position < subj.Buffer.Length 
                         && subj.Buffer[subj.Position] == '[' 
-                        && 0 != InlineMethods.ParseReference(subj))
+                        && 0 != InlineMethods.ParseReference(subj, settings))
                     {
                     }
 
@@ -200,13 +200,13 @@ namespace CommonMark.Parser
         /// Adds a new block as child of another. Return the child.
         /// </summary>
         /// <remarks>Original: add_child</remarks>
-        public static Block CreateChildBlock(Block parent, LineInfo line, BlockTag blockType, int startColumn)
+        public static Block CreateChildBlock(Block parent, LineInfo line, BlockTag blockType, int startColumn, CommonMarkSettings settings)
         {
             // if 'parent' isn't the kind of block that can accept this child,
             // then back up til we hit a block that can.
             while (!CanContain(parent.Tag, blockType))
             {
-                Finalize(parent, line);
+                Finalize(parent, line, settings);
                 parent = parent.Parent;
             }
 
@@ -295,7 +295,7 @@ namespace CommonMark.Parser
                         sc.FillSubject(subj);
                         delta = subj.Position;
 
-                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, parsers, specialCharacters);
+                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, parsers, specialCharacters, settings);
                         block.StringContent = null;
 
                         if (sc.PositionTracker != null)
@@ -431,7 +431,7 @@ namespace CommonMark.Parser
         // Process one line at a time, modifying a block.
         // Returns 0 if successful.  curptr is changed to point to
         // the currently open block.
-        public static void IncorporateLine(LineInfo line, ref Block curptr)
+        public static void IncorporateLine(LineInfo line, ref Block curptr, CommonMarkSettings settings)
         {
             var ln = line.Line;
 
@@ -594,7 +594,7 @@ namespace CommonMark.Parser
 
             // check to see if we've hit 2nd blank line, break out of list:
             if (blank && container.IsLastLineBlank)
-                BreakOutOfLists(ref container, line);
+                BreakOutOfLists(ref container, line, settings);
 
             var maybeLazy = cur.Tag == BlockTag.Paragraph;
 
@@ -622,21 +622,21 @@ namespace CommonMark.Parser
                         column++;
                     }
 
-                    container = CreateChildBlock(container, line, BlockTag.BlockQuote, first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.BlockQuote, first_nonspace, settings);
 
                 }
                 else if (!indented && curChar == '#' && 0 != (matched = Scanner.scan_atx_header_start(ln, first_nonspace, ln.Length, out i)))
                 {
 
                     AdvanceOffset(ln, first_nonspace + matched - offset, false, ref offset, ref column);
-                    container = CreateChildBlock(container, line, BlockTag.AtxHeader, first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.AtxHeader, first_nonspace, settings);
                     container.HeaderLevel = i;
 
                 }
                 else if (!indented && (curChar == '`' || curChar == '~') && 0 != (matched = Scanner.scan_open_code_fence(ln, first_nonspace, ln.Length)))
                 {
 
-                    container = CreateChildBlock(container, line, BlockTag.FencedCode, first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.FencedCode, first_nonspace, settings);
                     container.FencedCodeData = new FencedCodeData();
                     container.FencedCodeData.FenceChar = curChar;
                     container.FencedCodeData.FenceLength = matched;
@@ -651,7 +651,7 @@ namespace CommonMark.Parser
                     ))
                 {
 
-                    container = CreateChildBlock(container, line, BlockTag.HtmlBlock, first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.HtmlBlock, first_nonspace, settings);
                     container.HtmlBlockType = (HtmlBlockType)matched;
                     // note, we don't adjust offset because the tag is part of the text
 
@@ -672,8 +672,8 @@ namespace CommonMark.Parser
                 {
 
                     // it's only now that we know the line is not part of a setext header:
-                    container = CreateChildBlock(container, line, BlockTag.HorizontalRuler, first_nonspace);
-                    Finalize(container, line);
+                    container = CreateChildBlock(container, line, BlockTag.HorizontalRuler, first_nonspace, settings);
+                    Finalize(container, line, settings);
                     container = container.Parent;
                     AdvanceOffset(ln, ln.Length - 1 - offset, false, ref offset, ref column);
 
@@ -711,18 +711,18 @@ namespace CommonMark.Parser
 
                     if (container.Tag != BlockTag.List || !ListsMatch(container.ListData, data))
                     {
-                        container = CreateChildBlock(container, line, BlockTag.List, first_nonspace);
+                        container = CreateChildBlock(container, line, BlockTag.List, first_nonspace, settings);
                         container.ListData = data;
                     }
 
                     // add the list item
-                    container = CreateChildBlock(container, line, BlockTag.ListItem, first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.ListItem, first_nonspace, settings);
                     container.ListData = data;
                 }
                 else if (indented && !maybeLazy && !blank)
                 {
                     AdvanceOffset(ln, CODE_INDENT, true, ref offset, ref column);
-                    container = CreateChildBlock(container, line, BlockTag.IndentedCode, offset);
+                    container = CreateChildBlock(container, line, BlockTag.IndentedCode, offset, settings);
                 }
                 else
                 {
@@ -786,7 +786,7 @@ namespace CommonMark.Parser
                 while (cur != last_matched_container)
                 {
 
-                    Finalize(cur, line);
+                    Finalize(cur, line, settings);
                     cur = cur.Parent;
 
                     if (cur == null)
@@ -823,7 +823,7 @@ namespace CommonMark.Parser
 
                     if (Scanner.scan_html_block_end(container.HtmlBlockType, ln, first_nonspace, ln.Length))
                     {
-                        Finalize(container, line);
+                        Finalize(container, line, settings);
                         container = container.Parent;
                     }
 
@@ -852,7 +852,7 @@ namespace CommonMark.Parser
                         p = ln.Length - 1;
 
                     AddLine(container, line, ln, first_nonspace, p - first_nonspace + 1);
-                    Finalize(container, line);
+                    Finalize(container, line, settings);
                     container = container.Parent;
 
                 }
@@ -866,7 +866,7 @@ namespace CommonMark.Parser
                 {
 
                     // create paragraph container for line
-                    container = CreateChildBlock(container, line, BlockTag.Paragraph,  first_nonspace);
+                    container = CreateChildBlock(container, line, BlockTag.Paragraph, first_nonspace, settings);
                     AddLine(container, line, ln, first_nonspace);
 
                 }

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -17,7 +17,7 @@ namespace CommonMark.Parser
         internal static Func<Subject, CommonMarkSettings, Inline>[] InitializeParsers(CommonMarkSettings settings)
         {
             var handleCaret = 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SuperscriptCaret);
-            var handleTilde = 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.Tilde);
+            var handleTilde = 0 != (settings.AdditionalFeatures & (CommonMarkAdditionalFeatures.StrikethroughTilde | CommonMarkAdditionalFeatures.SubscriptTilde));
 
             var p = new Func<Subject, CommonMarkSettings, Inline>[handleTilde ? 127 : 97];
             p['\n'] = handle_newline;

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -44,12 +44,15 @@ namespace CommonMark.Parser
         /// <summary>
         /// Collapses internal whitespace to single space, removes leading/trailing whitespace, folds case.
         /// </summary>
-        private static string NormalizeReference(StringPart s)
+        private static string NormalizeReference(StringPart s, CommonMarkSettings settings)
         {
             if (s.Length == 0)
                 return string.Empty;
 
-            return NormalizeWhitespace(s.Source, s.StartIndex, s.Length).ToLowerInvariant();
+            var result = NormalizeWhitespace(s.Source, s.StartIndex, s.Length);
+            if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.RespectReferenceCase))
+                result = result.ToUpperInvariant();
+            return result;
         }
 
         /// <summary>
@@ -65,7 +68,7 @@ namespace CommonMark.Parser
             if (lab.Length > Reference.MaximumReferenceLabelLength)
                 return Reference.InvalidReference;
 
-            string label = NormalizeReference(lab);
+            string label = NormalizeReference(lab, settings);
 
             Reference r;
             if (refmap.TryGetValue(label, out r))
@@ -80,7 +83,7 @@ namespace CommonMark.Parser
         /// </summary>
         private static void AddReference(Dictionary<string, Reference> refmap, StringPart label, string url, string title, CommonMarkSettings settings)
         {
-            var normalizedLabel = NormalizeReference(label);
+            var normalizedLabel = NormalizeReference(label, settings);
             if (refmap.ContainsKey(normalizedLabel))
                 return;
 

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -434,13 +434,19 @@ namespace CommonMark.Parser
         private static Inline HandleTilde(Subject subj, CommonMarkSettings settings)
         {
             bool canOpen, canClose;
-            InlineTag? singleCharTag = null;
-            //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
-                singleCharTag = InlineTag.Subscript;
+            var numdelims = ScanEmphasisDelimeters(subj, '~', out canOpen, out canClose);
+
+            InlineTag? singleCharTag = InlineTag.Subscript;
+            if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
+            {
+                if (numdelims == 1)
+                    return new Inline("~", subj.Position - 1, subj.Position);
+                singleCharTag = null;
+            }
+
             InlineTag? doubleCharTag = null;
             //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
                 doubleCharTag = InlineTag.Strikethrough;
-            var numdelims = ScanEmphasisDelimeters(subj, '~', out canOpen, out canClose);
 
             if (canClose)
             {

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -444,9 +444,9 @@ namespace CommonMark.Parser
                 singleCharTag = null;
             }
 
-            InlineTag? doubleCharTag = null;
-            //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-                doubleCharTag = InlineTag.Strikethrough;
+            InlineTag? doubleCharTag = InlineTag.Strikethrough;
+            //if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+            //    doubleCharTag = null;
 
             if (canClose)
             {

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -17,7 +17,7 @@ namespace CommonMark.Parser
         internal static Func<Subject, CommonMarkSettings, Inline>[] InitializeParsers(CommonMarkSettings settings)
         {
             var handleCaret = 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SuperscriptCaret);
-            var handleTilde = 0 != (settings.AdditionalFeatures & (CommonMarkAdditionalFeatures.StrikethroughTilde | CommonMarkAdditionalFeatures.SubscriptTilde));
+            var handleTilde = 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.Tilde);
 
             var p = new Func<Subject, CommonMarkSettings, Inline>[handleTilde ? 127 : 97];
             p['\n'] = handle_newline;

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -448,7 +448,9 @@ namespace CommonMark.Parser
 
             InlineTag? doubleCharTag = InlineTag.Strikethrough;
             if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+            {
                 doubleCharTag = null;
+            }
 
             if (canClose)
             {
@@ -494,9 +496,6 @@ namespace CommonMark.Parser
         {
             bool canOpen, canClose;
             var numdelims = ScanEmphasisDelimeters(subj, '^', out canOpen, out canClose);
-
-            //if (numdelims > 1)
-            //    return new Inline("^", subj.Position - numdelims, subj.Position);
 
             if (canClose)
             {

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -40,15 +40,12 @@ namespace CommonMark.Parser
         /// <summary>
         /// Collapses internal whitespace to single space, removes leading/trailing whitespace, folds case.
         /// </summary>
-        private static string NormalizeReference(StringPart s, bool respectCase)
+        private static string NormalizeReference(StringPart s)
         {
             if (s.Length == 0)
                 return string.Empty;
 
-            string result = NormalizeWhitespace(s.Source, s.StartIndex, s.Length);
-            if (!respectCase)
-                result = result.ToLowerInvariant();
-            return result;
+            return NormalizeWhitespace(s.Source, s.StartIndex, s.Length).ToLowerInvariant();
         }
 
         /// <summary>
@@ -64,8 +61,7 @@ namespace CommonMark.Parser
             if (lab.Length > Reference.MaximumReferenceLabelLength)
                 return Reference.InvalidReference;
 
-            bool respectCase = (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.RespectReferenceCase) != CommonMarkAdditionalFeatures.None;
-            string label = NormalizeReference(lab, respectCase);
+            string label = NormalizeReference(lab);
 
             Reference r;
             if (refmap.TryGetValue(label, out r))
@@ -80,8 +76,7 @@ namespace CommonMark.Parser
         /// </summary>
         private static void AddReference(Dictionary<string, Reference> refmap, StringPart label, string url, string title, CommonMarkSettings settings)
         {
-            bool respectCase = (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.RespectReferenceCase) != CommonMarkAdditionalFeatures.None;
-            var normalizedLabel = NormalizeReference(label, respectCase);
+            var normalizedLabel = NormalizeReference(label);
             if (refmap.ContainsKey(normalizedLabel))
                 return;
 

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -434,12 +434,12 @@ namespace CommonMark.Parser
         private static Inline HandleTilde(Subject subj, CommonMarkSettings settings)
         {
             bool canOpen, canClose;
-            //InlineTag? singleCharTag = null;
+            InlineTag? singleCharTag = null;
             //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
-            //    singleCharTag = InlineTag.Subscript;
-            //InlineTag? doubleCharTag = null;
+                singleCharTag = InlineTag.Subscript;
+            InlineTag? doubleCharTag = null;
             //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-            //    doubleCharTag = InlineTag.Strikethrough;
+                doubleCharTag = InlineTag.Strikethrough;
             var numdelims = ScanEmphasisDelimeters(subj, '~', out canOpen, out canClose);
 
             if (canClose)
@@ -448,7 +448,7 @@ namespace CommonMark.Parser
                 var istack = InlineStack.FindMatchingOpener(subj.LastPendingInline, InlineStack.InlineStackPriority.Emphasis, '~', out canClose);
                 if (istack != null)
                 {
-                    var useDelims = MatchInlineStack(istack, subj, numdelims, null, InlineTag.Subscript, InlineTag.Strikethrough, settings);
+                    var useDelims = MatchInlineStack(istack, subj, numdelims, null, singleCharTag, doubleCharTag, settings);
 
                     // if the closer was not fully used, move back a char or two and try again.
                     if (useDelims < numdelims)

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -311,6 +311,8 @@ namespace CommonMark.Parser
             if (closingDelimeterCount < 3 || openerDelims < 3)
             {
                 useDelims = closingDelimeterCount <= openerDelims ? closingDelimeterCount : openerDelims;
+                if (useDelims == 2 && doubleCharTag == null)
+                    useDelims = 1;
                 if (useDelims == 1 && singleCharTag == null)
                     return 0;
             }
@@ -445,8 +447,8 @@ namespace CommonMark.Parser
             }
 
             InlineTag? doubleCharTag = InlineTag.Strikethrough;
-            //if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-            //    doubleCharTag = null;
+            if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+                doubleCharTag = null;
 
             if (canClose)
             {

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -114,7 +114,8 @@ namespace CommonMark.Parser
         /// <param name="first">The first entry to be removed.</param>
         /// <param name="subj">The subject associated with this stack. Can be <c>null</c> if the pointers in the subject should not be updated.</param>
         /// <param name="last">The last entry to be removed. Can be <c>null</c> if everything starting from <paramref name="first"/> has to be removed.</param>
-        public static void RemoveStackEntry(InlineStack first, Subject subj, InlineStack last)
+        /// <param name="settings">The object containing settings for the parsing process.</param>
+        public static void RemoveStackEntry(InlineStack first, Subject subj, InlineStack last, CommonMarkSettings settings)
         {
             var curPriority = first.Priority;
 
@@ -162,10 +163,10 @@ namespace CommonMark.Parser
             // this is not done automatically because the initial * is recognized as a potential closer (assuming
             // potential scenario '*[*' ).
             if (curPriority > 0)
-                PostProcessInlineStack(null, first, last, curPriority);
+                PostProcessInlineStack(null, first, last, curPriority, settings);
         }
 
-        public static void PostProcessInlineStack(Subject subj, InlineStack first, InlineStack last, InlineStackPriority ignorePriority)
+        public static void PostProcessInlineStack(Subject subj, InlineStack first, InlineStack last, InlineStackPriority ignorePriority, CommonMarkSettings settings)
         {
             while (ignorePriority > 0)
             {
@@ -174,7 +175,7 @@ namespace CommonMark.Parser
                 {
                     if (istack.Priority >= ignorePriority)
                     {
-                        RemoveStackEntry(istack, subj, istack);
+                        RemoveStackEntry(istack, subj, istack, settings);
                     }
                     else if (0 != (istack.Flags & InlineStackFlags.Closer))
                     {
@@ -185,13 +186,13 @@ namespace CommonMark.Parser
                             bool retry = false;
                             if (iopener.Delimeter == '~')
                             {
-                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, null, InlineTag.Strikethrough);
-                                if (istack.DelimeterCount > 1)
+                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, InlineTag.Subscript, InlineTag.Strikethrough, settings);
+                                if (istack.DelimeterCount > 0)
                                     retry = true;
                             }
                             else
                             {
-                                var useDelims = InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, InlineTag.Emphasis, InlineTag.Strong);
+                                var useDelims = InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, InlineTag.Emphasis, InlineTag.Strong, settings);
                                 if (istack.DelimeterCount > 0)
                                     retry = true;
                             }
@@ -200,14 +201,14 @@ namespace CommonMark.Parser
                             {
                                 // remove everything between opened and closer (not inclusive).
                                 if (istack.Previous != null && iopener.Next != istack.Previous)
-                                    RemoveStackEntry(iopener.Next, subj, istack.Previous);
+                                    RemoveStackEntry(iopener.Next, subj, istack.Previous, settings);
 
                                 continue;
                             }
                             else
                             {
                                 // remove opener, everything in between, and the closer
-                                RemoveStackEntry(iopener, subj, istack);
+                                RemoveStackEntry(iopener, subj, istack, settings);
                             }
                         }
                         else if (!canClose)

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -186,12 +186,12 @@ namespace CommonMark.Parser
                             bool retry = false;
                             if (iopener.Delimeter == '~')
                             {
-                                InlineTag? singleCharTag = null;
-                                //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
-                                    singleCharTag = InlineTag.Subscript;
-                                InlineTag? doubleCharTag = null;
-                                //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-                                    doubleCharTag = InlineTag.Strikethrough;
+                                InlineTag? singleCharTag = InlineTag.Subscript;
+                                if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
+                                    singleCharTag = null;
+                                InlineTag? doubleCharTag = InlineTag.Strikethrough;
+                                //if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+                                //    doubleCharTag = null;
                                 InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, singleCharTag, doubleCharTag, settings);
                                 if (istack.DelimeterCount > 0)
                                     retry = true;

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -184,24 +184,28 @@ namespace CommonMark.Parser
                         if (iopener != null)
                         {
                             bool retry = false;
+                            InlineTag? singleCharTag = null;
+                            InlineTag? doubleCharTag = null;
                             if (iopener.Delimeter == '~')
                             {
-                                InlineTag? singleCharTag = InlineTag.Subscript;
-                                if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
-                                    singleCharTag = null;
-                                InlineTag? doubleCharTag = InlineTag.Strikethrough;
-                                if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-                                    doubleCharTag = null;
-                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, singleCharTag, doubleCharTag, settings);
-                                if (istack.DelimeterCount > 0)
-                                    retry = true;
+                                if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
+                                    singleCharTag = InlineTag.Subscript;
+                                if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+                                    doubleCharTag = InlineTag.Strikethrough;
+                            }
+                            else if (iopener.Delimeter == '^' && 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SuperscriptCaret))
+                            {
+                                singleCharTag = InlineTag.Superscript;
                             }
                             else
                             {
-                                var useDelims = InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, InlineTag.Emphasis, InlineTag.Strong, settings);
-                                if (istack.DelimeterCount > 0)
-                                    retry = true;
+                                singleCharTag = InlineTag.Emphasis;
+                                doubleCharTag = InlineTag.Strong;
                             }
+
+                            var useDelims = InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, singleCharTag, doubleCharTag, settings);
+                            if (istack.DelimeterCount > 0)
+                                retry = true;
 
                             if (retry)
                             {

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -186,7 +186,13 @@ namespace CommonMark.Parser
                             bool retry = false;
                             if (iopener.Delimeter == '~')
                             {
-                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, InlineTag.Subscript, InlineTag.Strikethrough, settings);
+                                InlineTag? singleCharTag = null;
+                                //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
+                                    singleCharTag = InlineTag.Subscript;
+                                InlineTag? doubleCharTag = null;
+                                //if (0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+                                    doubleCharTag = InlineTag.Strikethrough;
+                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, singleCharTag, doubleCharTag, settings);
                                 if (istack.DelimeterCount > 0)
                                     retry = true;
                             }

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -190,8 +190,8 @@ namespace CommonMark.Parser
                                 if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.SubscriptTilde))
                                     singleCharTag = null;
                                 InlineTag? doubleCharTag = InlineTag.Strikethrough;
-                                //if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
-                                //    doubleCharTag = null;
+                                if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.StrikethroughTilde))
+                                    doubleCharTag = null;
                                 InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, singleCharTag, doubleCharTag, settings);
                                 if (istack.DelimeterCount > 0)
                                     retry = true;

--- a/CommonMark/Syntax/InlineTag.cs
+++ b/CommonMark/Syntax/InlineTag.cs
@@ -72,6 +72,18 @@ namespace CommonMark.Syntax
         /// Represents an inline element that has been "removed" (visually represented as strikethrough).
         /// Only present if the <see cref="CommonMarkAdditionalFeatures.StrikethroughTilde"/> is enabled.
         /// </summary>
-        Strikethrough
+        Strikethrough,
+
+        /// <summary>
+        /// Represents a subscript element.
+        /// Only present if the <see cref="CommonMarkAdditionalFeatures.SubscriptTilde"/> is enabled.
+        /// </summary>
+        Subscript,
+
+        /// <summary>
+        /// Represents a superscript element.
+        /// Only present if the <see cref="CommonMarkAdditionalFeatures.SuperscriptCaret"/> is enabled.
+        /// </summary>
+        Superscript,
     }
 }

--- a/CommonMark/packages.config
+++ b/CommonMark/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+</packages>


### PR DESCRIPTION
As discussed.

Please remove Microsoft.Net.Compilers and all the NuGet client stuff. I had to add those since I'm still on VS2013.

Thanks