### PR TITLE
Add Inline.DelimiterCharacter

### DIFF
--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -56,6 +56,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="DelimiterCharTests.cs" />
     <Compile Include="SourcePositionTests.cs" />
     <Compile Include="EnumeratorTests.cs" />
     <Compile Include="StrikethroughTests.cs" />

--- a/CommonMark.Tests/DelimiterCharTests.cs
+++ b/CommonMark.Tests/DelimiterCharTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class DelimiterCharTests
+    {
+        public DelimiterCharTests()
+        {
+        }
+
+        [TestMethod]
+        public void EmphasisDelimiterChar()
+        {
+            var md = "*foo*";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('*', doc.FirstChild.InlineContent.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void EmphasisDelimiterChar2()
+        {
+            var md = "_foo_";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('_', doc.FirstChild.InlineContent.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void EmphasisDelimiterChar3()
+        {
+            var md = "_foo[bar_";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('_', doc.FirstChild.InlineContent.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void EmphasisDelimiterChar4()
+        {
+            var md = "*foo[bar*";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('*', doc.FirstChild.InlineContent.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar()
+        {
+            var md = "_*foo*_";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('*', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar2()
+        {
+            var md = "*_foo_*";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('_', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar3()
+        {
+            var md = "_*foo[bar*_";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('*', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar4()
+        {
+            var md = "*_foo[bar_*";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('_', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar5()
+        {
+            var md = "_*foo[bar*baz_";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('*', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+
+        [TestMethod]
+        public void DoubleEmphasisDelimiterChar6()
+        {
+            var md = "*_foo[bar_baz*";
+            var doc = Helpers.ParseDocument(md);
+            Assert.AreEqual('_', doc.FirstChild.InlineContent.FirstChild.DelimiterCharacter);
+        }
+    }
+}

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -406,7 +406,7 @@ namespace CommonMark.Parser
                 }
             }
 
-            var inlText = new Inline(subj.Buffer, subj.Position - numdelims, numdelims, subj.Position - numdelims, subj.Position);
+            var inlText = new Inline(subj.Buffer, subj.Position - numdelims, numdelims, subj.Position - numdelims, subj.Position, c);
 
             if (canOpen || canClose)
             {
@@ -454,8 +454,7 @@ namespace CommonMark.Parser
                 }
             }
 
-            var inlText = new Inline(subj.Buffer, subj.Position - numdelims, numdelims,
-                subj.Position - numdelims, subj.Position);
+            var inlText = new Inline(subj.Buffer, subj.Position - numdelims, numdelims, subj.Position - numdelims, subj.Position, '~');
 
             if (canOpen || canClose)
             {
@@ -1042,7 +1041,7 @@ namespace CommonMark.Parser
                 while (endpos > startpos && subj.Buffer[endpos - 1] == ' ')
                     endpos--;
 
-            return new Inline(subj.Buffer, startpos, endpos - startpos, startpos, endpos);
+            return new Inline(subj.Buffer, startpos, endpos - startpos, startpos, endpos, c);
         }
 
         public static Inline parse_inlines(Subject subj, Dictionary<string, Reference> refmap, Func<Subject, Inline>[] parsers, char[] specialCharacters)

--- a/CommonMark/Syntax/Inline.cs
+++ b/CommonMark/Syntax/Inline.cs
@@ -210,10 +210,6 @@ namespace CommonMark.Syntax
         /// <summary>
         /// Gets the delimiter character for this inline element.
         /// </summary>
-        public char DelimiterCharacter
-        {
-            get;
-            private set;
-        }
+        public char DelimiterCharacter { get; }
     }
 }

--- a/CommonMark/Syntax/Inline.cs
+++ b/CommonMark/Syntax/Inline.cs
@@ -72,13 +72,14 @@ namespace CommonMark.Syntax
         /// <summary>
         /// Initializes a new instance of the <see cref="Inline"/> class. The element type is set to <see cref="InlineTag.String"/>
         /// </summary>
-        internal Inline(string content, int startIndex, int length, int sourcePosition, int sourceLastPosition)
+        internal Inline(string content, int startIndex, int length, int sourcePosition, int sourceLastPosition, char delimiterCharacter)
         {
             this.LiteralContentValue.Source = content;
             this.LiteralContentValue.StartIndex = startIndex;
             this.LiteralContentValue.Length = length; 
             this.SourcePosition = sourcePosition;
             this.SourceLastPosition = sourceLastPosition;
+            this.DelimiterCharacter = delimiterCharacter;
         }
 
         /// <summary>
@@ -204,6 +205,15 @@ namespace CommonMark.Syntax
 
                 return x;
             }
+        }
+
+        /// <summary>
+        /// Gets the delimiter character for this inline element.
+        /// </summary>
+        public char DelimiterCharacter
+        {
+            get;
+            private set;
         }
     }
 }


### PR DESCRIPTION
Hi,

This will allow client code to discover the char used for emphasis (`*` or `_`) or similar inlines (`~` and `^` if you merge sub/sup).