### PR TITLE
Parse emphasis in indented code

### DIFF
--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -57,6 +57,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="DelimiterCharTests.cs" />
+    <Compile Include="IndentedCodeTests.cs" />
     <Compile Include="SourcePositionTests.cs" />
     <Compile Include="EnumeratorTests.cs" />
     <Compile Include="StrikethroughTests.cs" />

--- a/CommonMark.Tests/IndentedCodeTests.cs
+++ b/CommonMark.Tests/IndentedCodeTests.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class IndentedCodeTests
+    {
+        private static CommonMarkSettings _settings;
+        private static CommonMarkSettings Settings
+        {
+            get
+            {
+                var s = _settings;
+                if (s == null)
+                {
+                    s = CommonMarkSettings.Default.Clone();
+                    s.AdditionalFeatures |= CommonMarkAdditionalFeatures.EmphasisInIndentedCode;
+                    _settings = s;
+                }
+                return s;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void EmphasisInIndentedCodeDisabledByDefault()
+        {
+            Helpers.ExecuteTest("\t_Hello_", "<pre><code>_Hello_\n</code></pre>");
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void EmphasisInIndentedCodeDisabledByDefault2()
+        {
+            Helpers.ExecuteTest("\t*Hello*", "<pre><code>*Hello*\n</code></pre>");
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void StrongEmphasisInIndentedCodeDisabledByDefault()
+        {
+            Helpers.ExecuteTest("\t__Hello__", "<pre><code>__Hello__\n</code></pre>");
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void StrongEmphasisInIndentedCodeDisabledByDefault2()
+        {
+            Helpers.ExecuteTest("\t**Hello**", "<pre><code>**Hello**\n</code></pre>");
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void EmphasisInIndentedCode()
+        {
+            Helpers.ExecuteTest("\t_Hello_", "<pre><code><em>Hello</em></code></pre>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void EmphasisInIndentedCode2()
+        {
+            Helpers.ExecuteTest("\t*Hello*", "<pre><code><em>Hello</em></code></pre>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void StrongEmphasisInIndentedCode()
+        {
+            Helpers.ExecuteTest("\t__Hello__", "<pre><code><strong>Hello</strong></code></pre>", Settings);
+        }
+
+        [TestMethod]
+        [TestCategory("Indented Code - Emphasis and strong emphasis")]
+        public void StrongEmphasisInIndentedCode2()
+        {
+            Helpers.ExecuteTest("\t**Hello**", "<pre><code><strong>Hello</strong></code></pre>", Settings);
+        }
+    }
+}

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,6 +21,11 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
+        /// The parser will recognize emphasis in indented code.
+        /// </summary>
+        EmphasisInIndentedCode = 32,
+
+        /// <summary>
         /// All additional features are enabled.
         /// </summary>
         All = 0x7FFFFFFF

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,7 +21,8 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
-        /// The parser will recognize emphasis in indented code.
+        /// The parser will recognize emphasis (text enclosed in single/double <c>*</c>/<c>_</c>) in indented code.
+        /// This is useful in rendering commands, e.g. <c>format **c:**</c>.
         /// </summary>
         EmphasisInIndentedCode = 32,
 

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -16,7 +16,9 @@ namespace CommonMark
         [Obsolete("Use CommonMarkSettings.Default.Clone() instead", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public CommonMarkSettings()
-        { }
+        {
+            Reset();
+        }
 
         /// <summary>
         /// Gets or sets the output format used by the last stage of conversion.
@@ -70,10 +72,7 @@ namespace CommonMark
             set
             {
                 this._additionalFeatures = value;
-                this._inlineParsers = null;
-                this._inlineParserSpecialCharacters = null;
-                this._inlineEmphasisParsers = null;
-                this._inlineParserEmphasisSpecialCharacters = null;
+                this.Reset();
             }
         }
 
@@ -122,7 +121,17 @@ namespace CommonMark
         /// </summary>
         public CommonMarkSettings Clone()
         {
-            return (CommonMarkSettings)this.MemberwiseClone();
+            var clone = (CommonMarkSettings)this.MemberwiseClone();
+            clone.Reset();
+            return clone;
+        }
+
+        private void Reset()
+        {
+            _inlineParsers = null;
+            _inlineParserSpecialCharacters = null;
+            _inlineEmphasisParsers = null;
+            _inlineParserEmphasisSpecialCharacters = null;
         }
 
         #region [ Properties that cache structures used in the parsers ]

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -67,7 +67,14 @@ namespace CommonMark
         public CommonMarkAdditionalFeatures AdditionalFeatures
         {
             get { return this._additionalFeatures; }
-            set { this._additionalFeatures = value; this._inlineParsers = null; this._inlineParserSpecialCharacters = null; }
+            set
+            {
+                this._additionalFeatures = value;
+                this._inlineParsers = null;
+                this._inlineParserSpecialCharacters = null;
+                this._inlineEmphasisParsers = null;
+                this._inlineParserEmphasisSpecialCharacters = null;
+            }
         }
 
         private Func<string, string> _uriResolver;
@@ -179,6 +186,31 @@ namespace CommonMark
                             vs.Add((char)i);
 
                     v = this._inlineParserSpecialCharacters = vs.ToArray();
+                }
+
+                return v;
+            }
+        }
+
+        private char[] _inlineParserEmphasisSpecialCharacters;
+
+        /// <summary>
+        /// Gets the characters that have special meaning for inline element emphasis parsers according to these settings.
+        /// </summary>
+        internal char[] InlineParserEmphasisSpecialCharacters
+        {
+            get
+            {
+                var v = this._inlineParserEmphasisSpecialCharacters;
+                if (v == null)
+                {
+                    var p = this.InlineEmphasisParsers;
+                    var vs = new List<char>(2);
+                    for (var i = 0; i < p.Length; i++)
+                        if (p[i] != null)
+                            vs.Add((char)i);
+
+                    v = this._inlineParserEmphasisSpecialCharacters = vs.ToArray();
                 }
 
                 return v;

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -140,6 +140,26 @@ namespace CommonMark
             }
         }
 
+        private Func<Parser.Subject, Syntax.Inline>[] _inlineEmphasisParsers;
+
+        /// <summary>
+        /// Gets the delegates that parse inline emphasis elements.
+        /// </summary>
+        internal Func<Parser.Subject, Syntax.Inline>[] InlineEmphasisParsers
+        {
+            get
+            {
+                var p = this._inlineEmphasisParsers;
+                if (p == null)
+                {
+                    p = Parser.InlineMethods.InitializeEmphasisParsers(this);
+                    this._inlineEmphasisParsers = p;
+                }
+
+                return p;
+            }
+        }
+
         private char[] _inlineParserSpecialCharacters;
 
         /// <summary>

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -217,6 +217,29 @@ namespace CommonMark.Formatters
                     break;
 
                 case BlockTag.IndentedCode:
+
+                    if (isOpening)
+                    {
+                        EnsureNewLine();
+
+                        Write("<pre><code");
+                        if (Settings.TrackSourcePosition)
+                            WritePositionAttribute(block);
+
+                        Write('>');
+                    }
+
+                    if (0 == (_settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
+                    {
+                        ignoreChildNodes = true;
+                        WriteEncodedHtml(block.StringContent);
+                    }
+
+                    if (isClosing)
+                        WriteLine("</code></pre>");
+
+                    break;
+
                 case BlockTag.FencedCode:
 
                     ignoreChildNodes = true;

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -227,12 +227,12 @@ namespace CommonMark.Formatters
                             WritePositionAttribute(block);
 
                         Write('>');
-                    }
 
-                    if (0 == (Settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
-                    {
-                        ignoreChildNodes = true;
-                        WriteEncodedHtml(block.StringContent);
+                        if (0 == (Settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
+                        {
+                            ignoreChildNodes = true;
+                            WriteEncodedHtml(block.StringContent);
+                        }
                     }
 
                     if (isClosing)

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -229,7 +229,7 @@ namespace CommonMark.Formatters
                         Write('>');
                     }
 
-                    if (0 == (_settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
+                    if (0 == (Settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
                     {
                         ignoreChildNodes = true;
                         WriteEncodedHtml(block.StringContent);

--- a/CommonMark/Formatters/HtmlFormatterSlim.cs
+++ b/CommonMark/Formatters/HtmlFormatterSlim.cs
@@ -316,6 +316,19 @@ namespace CommonMark.Formatters
                         break;
 
                     case BlockTag.IndentedCode:
+                        writer.EnsureLine();
+                        writer.WriteConstant("<pre><code");
+                        if (trackPositions) PrintPosition(writer, block);
+
+                        writer.Write('>');
+                        if (0 == (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode))
+                            EscapeHtml(block.StringContent, writer);
+                        else
+                            InlinesToHtml(writer, block.InlineContent, settings, inlineStack);
+
+                        writer.WriteLineConstant("</code></pre>");
+                        break;
+
                     case BlockTag.FencedCode:
                         writer.EnsureLine();
                         writer.WriteConstant("<pre><code");

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -277,6 +277,8 @@ namespace CommonMark.Parser
         {
             Stack<Inline> inlineStack = null;
             var stack = new Stack<Block>();
+            var parsers = settings.InlineParsers;
+            var emphasisParsers = settings.InlineEmphasisParsers;
             var specialCharacters = settings.InlineParserSpecialCharacters;
             var subj = new Subject(refmap);
 
@@ -298,10 +300,8 @@ namespace CommonMark.Parser
                         sc.FillSubject(subj);
                         delta = subj.Position;
 
-                        var parsers = parseEmphasisInIndentedCode
-                            ? settings.InlineEmphasisParsers
-                            : settings.InlineParsers;
-                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, parsers, specialCharacters);
+                        var inlineParsers = parseEmphasisInIndentedCode ? emphasisParsers : parsers;
+                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, inlineParsers, specialCharacters);
                         block.StringContent = null;
 
                         if (sc.PositionTracker != null)

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -302,7 +302,7 @@ namespace CommonMark.Parser
                         delta = subj.Position;
 
                         var inlineParsers = parseEmphasisInIndentedCode ? emphasisParsers : parsers;
-                        var inlineSpecialCharacters = parseEmphasisInIndentedCode ? specialCharacters : emphasisSpecialCharacters;
+                        var inlineSpecialCharacters = parseEmphasisInIndentedCode ? emphasisSpecialCharacters : specialCharacters;
                         block.InlineContent = InlineMethods.parse_inlines(subj, refmap, inlineParsers, inlineSpecialCharacters);
                         block.StringContent = null;
 

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -277,7 +277,6 @@ namespace CommonMark.Parser
         {
             Stack<Inline> inlineStack = null;
             var stack = new Stack<Block>();
-            var parsers = settings.InlineParsers;
             var specialCharacters = settings.InlineParserSpecialCharacters;
             var subj = new Subject(refmap);
 
@@ -287,7 +286,11 @@ namespace CommonMark.Parser
             while (block != null)
             {
                 var tag = block.Tag;
-                if (tag == BlockTag.Paragraph || tag == BlockTag.AtxHeader || tag == BlockTag.SETextHeader)
+
+                var parseEmphasisInIndentedCode =
+                    tag == BlockTag.IndentedCode
+                    && 0 != (settings.AdditionalFeatures & CommonMarkAdditionalFeatures.EmphasisInIndentedCode);
+                if (tag == BlockTag.Paragraph || tag == BlockTag.AtxHeader || tag == BlockTag.SETextHeader || parseEmphasisInIndentedCode)
                 {
                     sc = block.StringContent;
                     if (sc != null)
@@ -295,6 +298,9 @@ namespace CommonMark.Parser
                         sc.FillSubject(subj);
                         delta = subj.Position;
 
+                        var parsers = parseEmphasisInIndentedCode
+                            ? settings.InlineEmphasisParsers
+                            : settings.InlineParsers;
                         block.InlineContent = InlineMethods.parse_inlines(subj, refmap, parsers, specialCharacters);
                         block.StringContent = null;
 

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -280,6 +280,7 @@ namespace CommonMark.Parser
             var parsers = settings.InlineParsers;
             var emphasisParsers = settings.InlineEmphasisParsers;
             var specialCharacters = settings.InlineParserSpecialCharacters;
+            var emphasisSpecialCharacters = settings.InlineParserEmphasisSpecialCharacters;
             var subj = new Subject(refmap);
 
             StringContent sc;
@@ -301,7 +302,8 @@ namespace CommonMark.Parser
                         delta = subj.Position;
 
                         var inlineParsers = parseEmphasisInIndentedCode ? emphasisParsers : parsers;
-                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, inlineParsers, specialCharacters);
+                        var inlineSpecialCharacters = parseEmphasisInIndentedCode ? specialCharacters : emphasisSpecialCharacters;
+                        block.InlineContent = InlineMethods.parse_inlines(subj, refmap, inlineParsers, inlineSpecialCharacters);
                         block.StringContent = null;
 
                         if (sc.PositionTracker != null)

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -36,6 +36,16 @@ namespace CommonMark.Parser
             return p;
         }
 
+        /// <summary>
+        /// Initializes the array of delegates for inline emphasis parsing.
+        /// </summary>
+        /// <returns></returns>
+        internal static Func<Subject, Inline>[] InitializeEmphasisParsers(CommonMarkSettings settings)
+        {
+            var p = new Func<Subject, Inline>[96];
+            p['_'] = p['*'] = HandleEmphasis;
+            return p;
+        }
 
         /// <summary>
         /// Collapses internal whitespace to single space, removes leading/trailing whitespace, folds case.


### PR DESCRIPTION
This will allow `*` and `_` to be recognized inside indented code blocks.

As a bonus, both formatters have cleaner indented code handling.