### PR TITLE
Unbox inline tag chars

### DIFF
--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -295,7 +295,7 @@ namespace CommonMark.Parser
             return numdelims;
         }
 
-        internal static int MatchInlineStack(InlineStack opener, Subject subj, int closingDelimeterCount, InlineStack closer, InlineTag? singleCharTag, InlineTag? doubleCharTag)
+        internal static int MatchInlineStack(InlineStack opener, Subject subj, int closingDelimeterCount, InlineStack closer, InlineTag singleCharTag, InlineTag doubleCharTag)
         {
             // calculate the actual number of delimeters used from this closer
             int useDelims;
@@ -304,21 +304,22 @@ namespace CommonMark.Parser
             if (closingDelimeterCount < 3 || openerDelims < 3)
             {
                 useDelims = closingDelimeterCount <= openerDelims ? closingDelimeterCount : openerDelims;
-                if (useDelims == 1 && singleCharTag == null)
+                if (useDelims == 1 && singleCharTag == (InlineTag)0)
                     return 0;
             }
-            else if (singleCharTag == null)
+            else if (singleCharTag == (InlineTag)0)
                 useDelims = 2;
-            else if (doubleCharTag == null)
+            else if (doubleCharTag == (InlineTag)0)
                 useDelims = 1;
             else
                 useDelims = closingDelimeterCount % 2 == 0 ? 2 : 1;
 
             Inline inl = opener.StartingInline;
+            InlineTag tag = useDelims == 1 ? singleCharTag : doubleCharTag;
             if (openerDelims == useDelims)
             {
                 // the opener is completely used up - remove the stack entry and reuse the inline element
-                inl.Tag = useDelims == 1 ? singleCharTag.Value : doubleCharTag.Value;
+                inl.Tag = tag;
                 inl.LiteralContent = null;
                 inl.FirstChild = inl.NextSibling;
                 inl.NextSibling = null;
@@ -332,7 +333,7 @@ namespace CommonMark.Parser
                 inl.LiteralContent = inl.LiteralContent.Substring(0, opener.DelimeterCount);
                 inl.SourceLastPosition -= useDelims;
 
-                inl.NextSibling = new Inline(useDelims == 1 ? singleCharTag.Value : doubleCharTag.Value, inl.NextSibling);
+                inl.NextSibling = new Inline(tag, inl.NextSibling);
                 inl = inl.NextSibling;
 
                 inl.SourcePosition = opener.StartingInline.SourcePosition + opener.DelimeterCount;
@@ -385,10 +386,10 @@ namespace CommonMark.Parser
 
         private static Inline HandleTilde(Subject subj)
         {
-            return HandleOpenerCloser(subj, null, InlineTag.Strikethrough);
+            return HandleOpenerCloser(subj, (InlineTag)0, InlineTag.Strikethrough);
         }
 
-        private static Inline HandleOpenerCloser(Subject subj, InlineTag? singleCharTag, InlineTag? doubleCharTag)
+        private static Inline HandleOpenerCloser(Subject subj, InlineTag singleCharTag, InlineTag doubleCharTag)
         {
             bool canOpen, canClose;
             var c = subj.Buffer[subj.Position];

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -185,7 +185,7 @@ namespace CommonMark.Parser
                             bool retry = false;
                             if (iopener.Delimeter == '~')
                             {
-                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, null, InlineTag.Strikethrough);
+                                InlineMethods.MatchInlineStack(iopener, subj, istack.DelimeterCount, istack, (InlineTag)0, InlineTag.Strikethrough);
                                 if (istack.DelimeterCount > 1)
                                     retry = true;
                             }


### PR DESCRIPTION
This small optimization is meant to prevent boxing/unboxing the tag chars in `MatchInlineStack()`.

As an added bonus, code common to `HandleEmphasis()` and `HandleTilde()` is extracted as `HandleOpenerCloser()`.