### PR TITLE
Placeholders

### DIFF
--- a/CommonMark.Tests/CommonMark.Tests.csproj
+++ b/CommonMark.Tests/CommonMark.Tests.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="DelimiterCharTests.cs" />
     <Compile Include="HeadingTests.cs" />
+    <Compile Include="PlaceholderTests.cs" />
     <Compile Include="SourcePositionTests.cs" />
     <Compile Include="EnumeratorTests.cs" />
     <Compile Include="StrikethroughTests.cs" />

--- a/CommonMark.Tests/PlaceholderTests.cs
+++ b/CommonMark.Tests/PlaceholderTests.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMark.Tests
+{
+    [TestClass]
+    public class PlaceholderTests
+    {
+        private const string TEST_CATEGORY = "Inlines - Placeholder";
+
+        private static CommonMarkSettings _settings;
+        private static CommonMarkSettings Settings
+        {
+            get
+            {
+                var s = _settings;
+                if (s == null)
+                {
+                    s = CommonMarkSettings.Default.Clone();
+                    s.AdditionalFeatures |= CommonMarkAdditionalFeatures.PlaceholderBracket;
+                    _settings = s;
+                }
+                return s;
+            }
+        }
+
+        private static Formatters.HtmlFormatter CreatePrintPlaceholdersWithColonDollarHtmlFormatter(System.IO.TextWriter target, CommonMarkSettings stngs)
+        {
+            return new Formatters.HtmlFormatter(target, stngs)
+            {
+                PlaceholderResolver = placeholder => ":" + placeholder + "$"
+            };
+        }
+
+        private static Formatters.HtmlFormatter CreatePrintPlaceholdersWithColonDollarExcludesBHtmlFormatter(System.IO.TextWriter target, CommonMarkSettings stngs)
+        {
+            return new Formatters.HtmlFormatter(target, stngs)
+            {
+                PlaceholderResolver = placeholder => placeholder.Contains("b") ? null : ":" + placeholder + "$"
+            };
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersDisabledByDefault()
+        {
+            Helpers.ExecuteTest("foo [bar]", "<p>foo [bar]</p>");
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample1()
+        {
+            Helpers.ExecuteTest("foo [bar]", "<p>foo :bar$</p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample2()
+        {
+            Helpers.ExecuteTest("foo [[bar]", "<p>foo [:bar$</p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample3()
+        {
+            Helpers.ExecuteTest("foo [bar]]", "<p>foo :bar$]</p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample4()
+        {
+            Helpers.ExecuteTest("foo [ba[r]]", "<p>foo :ba[r]$</p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample5()
+        {
+            Helpers.ExecuteTest("f[oo] [ba]r", "<p>f:oo$ [ba]r</p>", Settings, CreatePrintPlaceholdersWithColonDollarExcludesBHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample6()
+        {
+            Helpers.ExecuteTest("f[oo] [*b*a]r", "<p>f:oo$ :*b*a$r</p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample7()
+        {
+            Helpers.ExecuteTest("f[oo] [*b*a]r", "<p>f:oo$ [<em>b</em>a]r</p>", Settings, CreatePrintPlaceholdersWithColonDollarExcludesBHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample8()
+        {
+            Helpers.ExecuteTest("foo **[bar]**", "<p>foo <strong>:bar$</strong></p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void PlaceholdersExample9()
+        {
+            Helpers.ExecuteTest("fo[o [ba]r](/url)", "<p>fo<a href=\"/url\">o :ba$r</a></p>", Settings, CreatePrintPlaceholdersWithColonDollarHtmlFormatter);
+        }
+    }
+}

--- a/CommonMark/CommonMarkAdditionalFeatures.cs
+++ b/CommonMark/CommonMarkAdditionalFeatures.cs
@@ -21,6 +21,11 @@ namespace CommonMark
         StrikethroughTilde = 1,
 
         /// <summary>
+        /// The parser will recognize syntax <c>[foo]</c>, which will be encoded in a separate AST node that the host application may evaluate as desired.
+        /// </summary>
+        PlaceholderBracket = 2,
+
+        /// <summary>
         /// All additional features are enabled.
         /// </summary>
         All = 0x7FFFFFFF

--- a/CommonMark/Formatters/HtmlFormatterSlim.cs
+++ b/CommonMark/Formatters/HtmlFormatterSlim.cs
@@ -630,7 +630,7 @@ namespace CommonMark.Formatters
 
                     case InlineTag.Placeholder:
                         // the slim formatter will treat placeholders like literals, without applying any further processing
-                        writer.WriteConstant("[");
+                        writer.Write('[');
                         if (trackPositions) PrintPosition(writer, inline);
                         stackLiteral = "]";
                         stackWithinLink = withinLink;

--- a/CommonMark/Formatters/HtmlFormatterSlim.cs
+++ b/CommonMark/Formatters/HtmlFormatterSlim.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -450,6 +451,12 @@ namespace CommonMark.Formatters
                         visitChildren = true;
                         break;
 
+                    case InlineTag.Placeholder:
+                        visitChildren = true;
+                        writer.Write('[');
+                        stackLiteral = "]";
+                        break;
+
                     default:
                         throw new CommonMarkException("Inline type " + inline.Tag + " is not supported.", inline);
                 }
@@ -619,6 +626,15 @@ namespace CommonMark.Formatters
                         stackLiteral = "</del>";
                         visitChildren = true;
                         stackWithinLink = withinLink;
+                        break;
+
+                    case InlineTag.Placeholder:
+                        // the slim formatter will treat placeholders like literals, without applying any further processing
+                        writer.WriteConstant("[");
+                        if (trackPositions) PrintPosition(writer, inline);
+                        stackLiteral = "]";
+                        stackWithinLink = withinLink;
+                        visitChildren = true;
                         break;
 
                     default:

--- a/CommonMark/Formatters/Printer.cs
+++ b/CommonMark/Formatters/Printer.cs
@@ -256,6 +256,13 @@ namespace CommonMark.Formatters
                                format_str(inline.LiteralContent, buffer));
                         break;
 
+                    case InlineTag.Placeholder:
+                        writer.Write("placeholder");
+                        PrintPosition(trackPositions, writer, inline);
+                        writer.Write(" url={0}",
+                               format_str(inline.TargetUrl, buffer));
+                        break;
+
                     case InlineTag.Image:
                         writer.Write("image");
                         PrintPosition(trackPositions, writer, inline);

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -28,7 +28,12 @@ namespace CommonMark.Parser
             p['_'] = HandleEmphasis;
             p['*'] = HandleEmphasis;
             p['['] = HandleLeftSquareBracket;
-            p[']'] = subj => HandleRightSquareBracket(subj, placeholderBracket);
+
+            if (placeholderBracket)
+                p[']'] = subj => HandleRightSquareBracket(subj, true);
+            else
+                p[']'] = subj => HandleRightSquareBracket(subj, false);
+            
             p['!'] = HandleExclamation;
 
             if (strikethroughTilde)
@@ -489,7 +494,7 @@ namespace CommonMark.Parser
                 inl.NextSibling = null;
                 inl.SourceLastPosition = subj.Position;
 
-                inl.TargetUrl = details.IsPlaceholder ? subj.Buffer.Substring(opener.StartPosition, subj.Position - opener.StartPosition - 1) : details.Url;
+                inl.TargetUrl = details.Url;
                 inl.LiteralContent = details.Title;
 
                 if (!isImage && !details.IsPlaceholder)
@@ -957,7 +962,11 @@ namespace CommonMark.Parser
             subj.Position = endlabel;
             if (supportPlaceholderBrackets)
             {
-                return new Reference() { IsPlaceholder = true };
+                return new Reference()
+                {
+                    Url = subj.Buffer.Substring(subj.LastPendingInline.StartPosition, subj.Position - subj.LastPendingInline.StartPosition - 1),
+                    IsPlaceholder = true
+                };
             }
             else
             {

--- a/CommonMark/Syntax/InlineTag.cs
+++ b/CommonMark/Syntax/InlineTag.cs
@@ -70,6 +70,14 @@ namespace CommonMark.Syntax
         /// Represents an inline element that has been "removed" (visually represented as strikethrough).
         /// Only present if the <see cref="CommonMarkAdditionalFeatures.StrikethroughTilde"/> is enabled.
         /// </summary>
-        Strikethrough
+        Strikethrough,
+
+        /// <summary>
+        /// Represents a placeholder for context-specific features (substituted by the host application).
+        /// If the host application does not process the placeholder, or the formatter does not support processing
+        /// of placeholders, the placeholder will be rendered as text, including its delimiters.
+        /// Only present if the <see cref="CommonMarkAdditionalFeatures.PlaceholderBracket"/> is enabled.
+        /// </summary>
+        Placeholder
     }
 }

--- a/CommonMark/Syntax/Reference.cs
+++ b/CommonMark/Syntax/Reference.cs
@@ -55,5 +55,10 @@ namespace CommonMark.Syntax
         /// Gets or sets the title of the reference (used in <c>&lt;a title="..."&gt;</c>).
         /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether the current reference is a placeholder: [foo]
+        /// </summary>
+        public bool IsPlaceholder { get; set; }
     }
 }


### PR DESCRIPTION
Following up to our [discussion in the issue tracker](https://github.com/Knagis/CommonMark.NET/issues/92), here's some code for supporting the described placeholders as an (optional) additional feature, including some test cases as well as HTML output support in the extendable HTML formatter.

If you choose to consider this feature for addition to the official library, please do not hesitate to let me know in case I still need to make any minor changes for conformancy with the existing code.