### PR TITLE
Apidoc reformatting

### DIFF
--- a/CommonMark/CommonMarkConverter.cs
+++ b/CommonMark/CommonMarkConverter.cs
@@ -89,7 +89,7 @@ namespace CommonMark
         /// <param name="source">The reader that contains the source data.</param>
         /// <param name="settings">The object containing settings for the parsing process.</param>
         /// <returns>The block element that represents the document.</returns>
-        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during block parsing.</exception>
         /// <exception cref="IOException">when error occur while reading the data.</exception>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Advanced)] 
@@ -154,7 +154,7 @@ namespace CommonMark
         /// <param name="document">The top level document element.</param>
         /// <param name="settings">The object containing settings for the parsing process.</param>
         /// <exception cref="ArgumentException">when <paramref name="document"/> does not represent a top level document.</exception>
-        /// <exception cref="ArgumentNullException">when <paramref name="document"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="document"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during inline parsing.</exception>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Advanced)] 
         public static void ProcessStage2(Syntax.Block document, CommonMarkSettings settings = null)
@@ -189,7 +189,7 @@ namespace CommonMark
         /// <param name="target">The target text writer where the result will be written to.</param>
         /// <param name="settings">The object containing settings for the formatting process.</param>
         /// <exception cref="ArgumentException">when <paramref name="document"/> does not represent a top level document.</exception>
-        /// <exception cref="ArgumentNullException">when <paramref name="document"/> or <paramref name="target"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="document"/> or <paramref name="target"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during formatting.</exception>
         /// <exception cref="IOException">when error occur while writing the data to the target.</exception>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Advanced)] 
@@ -246,7 +246,7 @@ namespace CommonMark
         /// </summary>
         /// <param name="source">The reader that contains the source data.</param>
         /// <param name="settings">The object containing settings for the parsing and formatting process.</param>
-        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during parsing.</exception>
         /// <exception cref="IOException">when error occur while reading or writing the data.</exception>
         public static Syntax.Block Parse(TextReader source, CommonMarkSettings settings = null)
@@ -265,7 +265,7 @@ namespace CommonMark
         /// </summary>
         /// <param name="source">The source data.</param>
         /// <param name="settings">The object containing settings for the parsing and formatting process.</param>
-        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="source"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during parsing.</exception>
         /// <exception cref="IOException">when error occur while reading or writing the data.</exception>
         public static Syntax.Block Parse(string source, CommonMarkSettings settings = null)
@@ -283,7 +283,7 @@ namespace CommonMark
         /// <param name="source">The reader that contains the source data.</param>
         /// <param name="target">The target text writer where the result will be written to.</param>
         /// <param name="settings">The object containing settings for the parsing and formatting process.</param>
-        /// <exception cref="ArgumentNullException">when <paramref name="source"/> or <paramref name="target"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="source"/> or <paramref name="target"/> is <see langword="null"/></exception>
         /// <exception cref="CommonMarkException">when errors occur during parsing or formatting.</exception>
         /// <exception cref="IOException">when error occur while reading or writing the data.</exception>
         public static void Convert(TextReader source, TextWriter target, CommonMarkSettings settings = null)

--- a/CommonMark/CommonMarkException.cs
+++ b/CommonMark/CommonMarkException.cs
@@ -14,12 +14,12 @@ namespace CommonMark
     public class CommonMarkException : Exception
     {
         /// <summary>
-        /// Gets the block that caused the exception. Can be <c>null</c>.
+        /// Gets the block that caused the exception. Can be <see langword="null"/>.
         /// </summary>
         public Block BlockElement { get; private set; }
 
         /// <summary>
-        /// Gets the inline element that caused the exception. Can be <c>null</c>.
+        /// Gets the inline element that caused the exception. Can be <see langword="null"/>.
         /// </summary>
         public Inline InlineElement { get; private set; }
 
@@ -32,13 +32,13 @@ namespace CommonMark
 
         /// <summary>Initializes a new instance of the <see cref="CommonMarkException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <see langword="null"/> if no inner exception is specified.</param>
         public CommonMarkException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>Initializes a new instance of the <see cref="CommonMarkException" /> class with a specified error message, a reference to the element that caused it and a reference to the inner exception that is the cause of this exception.</summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="inline">The inline element that is related to the exception cause.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <see langword="null"/> if no inner exception is specified.</param>
         public CommonMarkException(string message, Inline inline, Exception innerException = null)
             : base(message, innerException)
         {
@@ -48,7 +48,7 @@ namespace CommonMark
         /// <summary>Initializes a new instance of the <see cref="CommonMarkException" /> class with a specified error message, a reference to the element that caused it and a reference to the inner exception that is the cause of this exception.</summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="block">The block element that is related to the exception cause.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <see langword="null"/> if no inner exception is specified.</param>
         public CommonMarkException(string message, Block block, Exception innerException = null)
             : base(message, innerException) 
         {
@@ -74,7 +74,7 @@ namespace CommonMark
         /// <summary>Sets the <see cref="System.Runtime.Serialization.SerializationInfo" /> with information about the exception.</summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="info" /> parameter is a <c>null</c> reference (<c>Nothing</c> in Visual Basic).</exception>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="info" /> parameter is <see langword="null"/>.</exception>
         [System.Security.SecurityCritical]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {

--- a/CommonMark/CommonMarkSettings.cs
+++ b/CommonMark/CommonMarkSettings.cs
@@ -50,7 +50,7 @@ namespace CommonMark
         /// Gets or sets a value indicating whether the parser tracks precise positions in the source data for
         /// block and inline elements. This is disabled by default because it incurs an additional performance cost to
         /// keep track of the original position.
-        /// Setting this to <c>true</c> will populate <see cref="Syntax.Inline.SourcePosition"/>, 
+        /// Setting this to <see langword="true"/> will populate <see cref="Syntax.Inline.SourcePosition"/>, 
         /// <see cref="Syntax.Inline.SourceLength"/>, <see cref="Syntax.Block.SourcePosition"/> and 
         /// <see cref="Syntax.Block.SourceLength"/> properties with correct information, otherwise the values
         /// of these properties are undefined.

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -36,7 +36,7 @@ namespace CommonMark.Formatters
         /// <summary>Initializes a new instance of the <see cref="HtmlFormatter" /> class.</summary>
         /// <param name="target">The target text writer.</param>
         /// <param name="settings">The settings used when formatting the data.</param>
-        /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <see langword="null"/></exception>
         public HtmlFormatter(TextWriter target, CommonMarkSettings settings)
         {
             if (target == null)

--- a/CommonMark/Formatters/HtmlFormatter.cs
+++ b/CommonMark/Formatters/HtmlFormatter.cs
@@ -108,7 +108,7 @@ namespace CommonMark.Formatters
         /// <param name="isOpening">Specifies whether the block element is being opened (or started).</param>
         /// <param name="isClosing">Specifies whether the block element is being closed. If the block does not
         /// have child nodes, then both <paramref name="isClosing"/> and <paramref name="isOpening"/> can be
-        /// <c>true</c> at the same time.</param>
+        /// <see langword="true"/> at the same time.</param>
         /// <param name="ignoreChildNodes">Instructs the caller whether to skip processing of child nodes or not.</param>
         protected virtual void WriteBlock(Block block, bool isOpening, bool isClosing, out bool ignoreChildNodes)
         {
@@ -284,7 +284,7 @@ namespace CommonMark.Formatters
         /// <param name="isOpening">Specifies whether the inline element is being opened (or started).</param>
         /// <param name="isClosing">Specifies whether the inline element is being closed. If the inline does not
         /// have child nodes, then both <paramref name="isClosing"/> and <paramref name="isOpening"/> can be
-        /// <c>true</c> at the same time.</param>
+        /// <see langword="true"/> at the same time.</param>
         /// <param name="ignoreChildNodes">Instructs the caller whether to skip processing of child nodes or not.</param>
         protected virtual void WriteInline(Inline inline, bool isOpening, bool isClosing, out bool ignoreChildNodes)
         {
@@ -643,7 +643,7 @@ namespace CommonMark.Formatters
 
         /// <summary>
         /// Writes a <c>data-sourcepos="start-end"</c> attribute to the target writer. 
-        /// This method should only be called if <see cref="CommonMarkSettings.TrackSourcePosition"/> is set to <c>true</c>.
+        /// This method should only be called if <see cref="CommonMarkSettings.TrackSourcePosition"/> is set to <see langword="true"/>.
         /// Note that the attribute is preceded (but not succeeded) by a single space.
         /// </summary>
         protected void WritePositionAttribute(Block block)
@@ -653,7 +653,7 @@ namespace CommonMark.Formatters
 
         /// <summary>
         /// Writes a <c>data-sourcepos="start-end"</c> attribute to the target writer. 
-        /// This method should only be called if <see cref="CommonMarkSettings.TrackSourcePosition"/> is set to <c>true</c>.
+        /// This method should only be called if <see cref="CommonMarkSettings.TrackSourcePosition"/> is set to <see langword="true"/>.
         /// Note that the attribute is preceded (but not succeeded) by a single space.
         /// </summary>
         protected void WritePositionAttribute(Inline inline)

--- a/CommonMark/Parser/EntityDecoder.cs
+++ b/CommonMark/Parser/EntityDecoder.cs
@@ -10,7 +10,7 @@ namespace CommonMark.Parser
         /// Decodes the given HTML entity to the matching Unicode characters.
         /// </summary>
         /// <param name="entity">The entity without <c>&amp;</c> and <c>;</c> symbols, for example, <c>copy</c>.</param>
-        /// <returns>The unicode character set or <c>null</c> if the entity was not recognized.</returns>
+        /// <returns>The unicode character set or <see langword="null"/> if the entity was not recognized.</returns>
         public static string DecodeEntity(string entity)
         {
             string result;
@@ -23,7 +23,7 @@ namespace CommonMark.Parser
         /// <summary>
         /// Decodes the given UTF-32 character code to the matching set of UTF-16 characters.
         /// </summary>
-        /// <returns>The unicode character set or <c>null</c> if the entity was not recognized.</returns>
+        /// <returns>The unicode character set or <see langword="null"/> if the entity was not recognized.</returns>
         public static string DecodeEntity(int utf32)
         {
             if (utf32 < 0 || utf32 > 1114111 || (utf32 >= 55296 && utf32 <= 57343))

--- a/CommonMark/Parser/InlineMethods.cs
+++ b/CommonMark/Parser/InlineMethods.cs
@@ -56,7 +56,7 @@ namespace CommonMark.Parser
 
         /// <summary>
         /// Checks if the reference dictionary contains a reference with the given label and returns it,
-        /// otherwise returns <c>null</c>.
+        /// otherwise returns <see langword="null"/>.
         /// Returns <see cref="Reference.InvalidReference"/> if the reference label is not valid.
         /// </summary>
         private static Reference LookupReference(DocumentData data, StringPart lab)

--- a/CommonMark/Parser/InlineStack.cs
+++ b/CommonMark/Parser/InlineStack.cs
@@ -14,12 +14,12 @@ namespace CommonMark.Parser
         public InlineStackPriority Priority;
 
         /// <summary>
-        /// Previous entry in the stack. <c>null</c> if this is the last one.
+        /// Previous entry in the stack; <see langword="null"/> if this is the last one.
         /// </summary>
         public InlineStack Previous;
 
         /// <summary>
-        /// Next entry in the stack. <c>null</c> if this is the last one.
+        /// Next entry in the stack; <see langword="null"/> if this is the last one.
         /// </summary>
         public InlineStack Next;
 
@@ -112,8 +112,8 @@ namespace CommonMark.Parser
         /// Removes a subset of the stack.
         /// </summary>
         /// <param name="first">The first entry to be removed.</param>
-        /// <param name="subj">The subject associated with this stack. Can be <c>null</c> if the pointers in the subject should not be updated.</param>
-        /// <param name="last">The last entry to be removed. Can be <c>null</c> if everything starting from <paramref name="first"/> has to be removed.</param>
+        /// <param name="subj">The subject associated with this stack. Can be <see langword="null"/> if the pointers in the subject should not be updated.</param>
+        /// <param name="last">The last entry to be removed. Can be <see langword="null"/> if everything starting from <paramref name="first"/> has to be removed.</param>
         public static void RemoveStackEntry(InlineStack first, Subject subj, InlineStack last)
         {
             var curPriority = first.Priority;

--- a/CommonMark/Parser/Subject.cs
+++ b/CommonMark/Parser/Subject.cs
@@ -53,12 +53,12 @@ namespace CommonMark.Parser
         public Inline LastInline;
 
         /// <summary>
-        /// The last entry of the current stack of possible emphasis openers. Can be <c>null</c>.
+        /// The last entry of the current stack of possible emphasis openers. Can be <see langword="null"/>.
         /// </summary>
         public InlineStack LastPendingInline;
 
         /// <summary>
-        /// The first entry of the current stack of possible emphasis openers. Can be <c>null</c>.
+        /// The first entry of the current stack of possible emphasis openers. Can be <see langword="null"/>.
         /// </summary>
         public InlineStack FirstPendingInline;
 

--- a/CommonMark/Syntax/Block.cs
+++ b/CommonMark/Syntax/Block.cs
@@ -131,13 +131,13 @@ namespace CommonMark.Syntax
         public bool IsLastLineBlank { get; set; }
 
         /// <summary>
-        /// Gets or sets the first child element of this instance. <c>null</c> if there are no children.
+        /// Gets or sets the first child element of this instance, or <see langword="null"/> if there are no children.
         /// </summary>
         public Block FirstChild { get; set; }
 
         /// <summary>
         /// Gets or sets the last child element (the last sibling of <see cref="FirstChild"/>) of this instance. 
-        /// <c>null</c> if there are no children.
+        /// <see langword="null"/> if there are no children.
         /// </summary>
         public Block LastChild { get; set; }
 
@@ -160,7 +160,7 @@ namespace CommonMark.Syntax
 
         /// <summary>
         /// Gets or sets the first inline element that was parsed from <see cref="StringContent"/> property.
-        /// Note that once the inlines are parsed, <see cref="StringContent"/> will be set to <c>null</c>.
+        /// Note that once the inlines are parsed, <see cref="StringContent"/> will be set to <see langword="null"/>.
         /// </summary>
         public Inline InlineContent { get; set; }
 
@@ -216,12 +216,12 @@ namespace CommonMark.Syntax
         }
 
         /// <summary>
-        /// Gets or sets the next sibling of this block element. <c>null</c> if this is the last element.
+        /// Gets or sets the next sibling of this block element; <see langword="null"/> if this is the last element.
         /// </summary>
         public Block NextSibling { get; set; }
 
         /// <summary>
-        /// Gets or sets the previous sibling of this block element. <c>null</c> if this is the first element.
+        /// Gets or sets the previous sibling of this block element; <see langword="null"/> if this is the first element.
         /// </summary>
         [Obsolete("This property will be removed in future. If you have a use case where this property is required, please log an issue at https://github.com/Knagis/CommonMark.NET", false)]
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/CommonMark/Syntax/DocumentData.cs
+++ b/CommonMark/Syntax/DocumentData.cs
@@ -8,7 +8,7 @@ namespace CommonMark.Syntax
     public class DocumentData
     {
         /// <summary>
-        /// Gets or sets the dictionary containing resolved link references. Only set on the document node, <c>null</c>
+        /// Gets or sets the dictionary containing resolved link references. Only set on the document node, <see langword="null"/>
         /// and not used for all other elements.
         /// </summary>
         public Dictionary<string, Reference> ReferenceMap { get; set; }

--- a/CommonMark/Syntax/EnumeratorEntry.cs
+++ b/CommonMark/Syntax/EnumeratorEntry.cs
@@ -49,7 +49,7 @@ namespace CommonMark.Syntax
         /// <summary>
         /// Gets the value indicating whether this instance represents the closing of the element (returned by the
         /// enumerator after the children have been enumerated). Both <see name="IsOpening"/> and <see name="IsClosing"/>
-        /// can be <c>true</c> at the same time if there are no children for the given element.
+        /// can be <see langword="true"/> at the same time if there are no children for the given element.
         /// </summary>
         public bool IsClosing { get; private set; }
 

--- a/CommonMark/Syntax/EnumeratorEntry.cs
+++ b/CommonMark/Syntax/EnumeratorEntry.cs
@@ -54,12 +54,12 @@ namespace CommonMark.Syntax
         public bool IsClosing { get; private set; }
 
         /// <summary>
-        /// Gets the inline element. Can be <c>null</c> if <see cref="Block"/> is set.
+        /// Gets the inline element. Can be <see langword="null"/> if <see cref="Block"/> is set.
         /// </summary>
         public Inline Inline { get; private set; }
 
         /// <summary>
-        /// Gets the block element. Can be <c>null</c> if <see cref="Inline"/> is set.
+        /// Gets the block element. Can be <see langword="null"/> if <see cref="Inline"/> is set.
         /// </summary>
         public Block Block { get; private set; }
 

--- a/CommonMark/Syntax/Inline.cs
+++ b/CommonMark/Syntax/Inline.cs
@@ -179,7 +179,7 @@ namespace CommonMark.Syntax
         private Inline _next;
 
         /// <summary>
-        /// Gets the next sibling inline element. Returns <c>null</c> if this is the last element.
+        /// Gets the next sibling inline element. Returns <see langword="null"/> if this is the last element.
         /// </summary>
         public Inline NextSibling
         {

--- a/CommonMark/Syntax/StringContent.cs
+++ b/CommonMark/Syntax/StringContent.cs
@@ -214,7 +214,7 @@ namespace CommonMark.Syntax
         /// Optionally the returned characters are removed from this instance.
         /// </summary>
         /// <param name="length">The number of characters to return.</param>
-        /// <param name="trim">If set to <c>true</c>, the characters are removed from this instance.</param>
+        /// <param name="trim">If set to <see langword="true"/>, the characters are removed from this instance.</param>
         public string TakeFromStart(int length, bool trim = false)
         {
             // does not use StringBuilder because in most cases the substring will be taken from just the first part


### PR DESCRIPTION
Following up to the [comments on my first API docs fix PR](https://github.com/Knagis/CommonMark.NET/pull/94#issuecomment-245700237), here is a replacement of the language keywords `null` and `true` (`false` didn't occur anywhere in the API docs, it seems) with the `<see langword="..."/>` tag.