### PR TITLE
Fix Incorrect source position mapping when a list containes tabbed items

### DIFF
--- a/CommonMark.Tests/SourcePositionTests.cs
+++ b/CommonMark.Tests/SourcePositionTests.cs
@@ -148,6 +148,60 @@ is it?
 
         [TestMethod]
         [TestCategory("SourcePosition")]
+        public void SourcePositionComplexWithNestedBlocks() {
+            var data = "1. One\n\t11. OneOne";
+            var doc = Helpers.ParseDocument(data, Settings);
+
+
+            var inlinesQ = doc.AsEnumerable()
+                .Where(o => o.Inline != null && o.IsOpening)
+                .Select(o => o.Inline.SourceLength < 0 ? null : data.Substring(o.Inline.SourcePosition, o.Inline.SourceLength));
+
+            var inlines = new HashSet<string>(inlinesQ, StringComparer.Ordinal);
+
+            var expectedInlines = new[]
+            {
+                "One",
+                "11. OneOne"
+            };
+
+            foreach (var ei in expectedInlines) {
+                if (!inlines.Contains(ei))
+                    Assert.Fail("Inline '{0}' was not parsed with correct source positions.", ei);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("SourcePosition")]
+        public void SourcePositionComplexWithNestedBlocks2() {
+            var data = "1. One\n\t11. OneOne\n\t12. OneTwo\n\t13. OneThree\n2. Two\n\nSimpleText";
+            var doc = Helpers.ParseDocument(data, Settings);
+
+
+            var inlinesQ = doc.AsEnumerable()
+                .Where(o => o.Inline != null && o.IsOpening)
+                .Select(o => o.Inline.SourceLength < 0 ? null : data.Substring(o.Inline.SourcePosition, o.Inline.SourceLength));
+
+            var inlines = new HashSet<string>(inlinesQ, StringComparer.Ordinal);
+
+            var expectedInlines = new[]
+            {
+                "One",
+                "11. OneOne",
+                "12. OneTwo",
+                "13. OneThree",
+                "Two",
+                "SimpleText"
+            };
+
+            foreach (var ei in expectedInlines) {
+                if (!inlines.Contains(ei))
+                    Assert.Fail("Inline '{0}' was not parsed with correct source positions.", ei);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("SourcePosition")]
         public void SourcePositionComplex()
         {
             var data = "\0\0   **foo**\r\n\t\0bar \n\n> *quoting **is nice***, `right`?";

--- a/CommonMark/Parser/BlockMethods.cs
+++ b/CommonMark/Parser/BlockMethods.cs
@@ -32,7 +32,7 @@ namespace CommonMark.Parser
                     block_type == BlockTag.FencedCode);
         }
 
-        private static void AddLine(Block block, LineInfo lineInfo, string ln, int offset, int remainingSpaces, int length = -1)
+        private static void AddLine(Block block, LineInfo lineInfo, string ln, int offset, int remainingSpaces, int length = -1, bool isAddOffsetRequired = true)
         {
             if (!block.IsOpen)
                 throw new CommonMarkException(string.Format(CultureInfo.InvariantCulture, "Attempted to add line '{0}' to closed container ({1}).", ln, block.Tag));
@@ -49,7 +49,7 @@ namespace CommonMark.Parser
                     curSC.PositionTracker = new PositionTracker(lineInfo.LineOffset);
             }
 
-            if (lineInfo.IsTrackingPositions)
+            if (lineInfo.IsTrackingPositions && isAddOffsetRequired)
                 curSC.PositionTracker.AddOffset(lineInfo, offset, len);
 
             curSC.Append(Spaces, 0, remainingSpaces);
@@ -901,7 +901,7 @@ namespace CommonMark.Parser
                 else if (AcceptsLines(container.Tag))
                 {
 
-                    AddLine(container, line, ln, first_nonspace, remainingSpaces);
+                    AddLine(container, line, ln, first_nonspace, remainingSpaces, isAddOffsetRequired: container.Parent == null || container.Parent.Tag == BlockTag.Document);
 
                 }
                 else if (container.Tag != BlockTag.ThematicBreak && container.Tag != BlockTag.SetextHeading)


### PR DESCRIPTION
The problem appears in the following case:
```
1. List First Line
    12. Tabbed Line
```
The structure of the blocks is looks like this:
List Block
  Pargraph Block
     Inline Block 'List First Line\n'
     Inline Block '12. Tabbed Line\n'

The last inline block source position is shifted to the right by one character due to the extra offset object ('2. Tabbed Line\n\0')

The pull request contains two unit tests showing the problem.
